### PR TITLE
Update Travis not use --dev

### DIFF
--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -21,8 +21,8 @@ function installToMediaWikiRoot {
 	then
 		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
 	else
-		composer init --stability dev
-		composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev --update-with-dependencies
+		composer init
+		composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --update-with-dependencies
 
 		cd extensions
 		cd SemanticFormsSelect


### PR DESCRIPTION
This avoids an issue with an unstable SF as seen in #5 and adheres restrictions as defined by 641a3ab to pass the tests.

```
Semantic Forms Select: 1.3.0

Semantic MediaWiki: 2.3.1 (SMWSQLStore3, mysql)
MediaWiki:          1.26.2 (MediaWiki vendor autoloader)

PHPUnit 3.7.38 by Sebastian Bergmann.

Configuration read from /home/travis/build/SemanticMediaWiki/mw/extensions/SemanticFormsSelect/phpunit.xml.dist

.........

Time: 259 ms, Memory: 26.00Mb
```