### PR TITLE
Fix support for SemanticForms extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
   include:
     - env: DB=mysql; MW=1.26.2;
       php: 7
-    - env: DB=mysql; MW=1.26.2;
-      php: 5.6
     - env: DB=mysql; MW=1.25.5; TYPE=coverage
       php: 5.6
     - env: DB=sqlite; MW=1.23.13;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 matrix:
   fast_finish: true
   include:
-
     - env: DB=mysql; MW=master;
       php: 7
     - env: DB=mysql; MW=1.26.2;

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
   include:
     - env: DB=mysql; MW=1.26.2;
       php: 7
+    - env: DB=mysql; MW=1.26.2;
+      php: 5.6
     - env: DB=mysql; MW=1.25.5; TYPE=coverage
       php: 5.6
     - env: DB=sqlite; MW=1.23.13;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
 matrix:
   fast_finish: true
   include:
+    - env: DB=mysql; MW=master;
+      php: 7
     - env: DB=mysql; MW=1.26.2;
       php: 7
     - env: DB=mysql; MW=1.25.5; TYPE=coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 matrix:
   fast_finish: true
   include:
+
     - env: DB=mysql; MW=master;
       php: 7
     - env: DB=mysql; MW=1.26.2;

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -65,8 +65,8 @@ call_user_func( function() {
 		)
 	);
 
-	$GLOBALS['wgExtensionFunctions'][] = function() {
+	// $GLOBALS['wgExtensionFunctions'][] = function() {
 		$GLOBALS['sfgFormPrinter']->setInputTypeHook( 'SF_Select', '\SFS\SemanticFormsSelect::init', array() );
-	};
+	// };
 
 } );

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -18,6 +18,17 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }
 
+// A workaround to stay compatible with the 3.4.x release.
+if ( defined( 'SMW_VERSION' ) ) {
+	$GLOBALS['wgExtensionFunctions'][] = function() {
+		// This global variable is needed so that other extensions can
+		// hook into it to add their own input types.
+		$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
+	};
+} else {
+	$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
+}
+
 $GLOBALS['wgExtensionFunctions'][] = function() {
 	if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
 		die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -19,8 +19,10 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 }
 
 $GLOBALS['wgExtensionFunctions'][] = function() {
-	if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
-		die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );
+	if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.26c', '<' ) ) {
+		if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
+			die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );
+		}
 	}
 };
 

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -10,8 +10,8 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'This file is part of the SemanticFormsSelect extension, it is not a valid entry point.' );
 }
 
-if ( file_exists( __DIR__ . '/../../vendor/autoload.php' ) ) {
-	require_once( __DIR__ . '/../../vendor/autoload.php' );
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once( __DIR__ . '/vendor/autoload.php' );
 }
 
 if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
@@ -19,7 +19,7 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 }
 
 $GLOBALS['wgExtensionFunctions'][] = function() {
-	if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
+	if ( version_compare( SF_VERSION, '6.8', '<' ) ) {
 		die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );
 	}
 };

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -34,7 +34,7 @@ define( 'SFS_VERSION', '1.3.0' );
 /**
  * @codeCoverageIgnore
  */
-// call_user_func( function() {
+call_user_func( function() {
 
 	$GLOBALS['wgExtensionCredits']['semantic'][] = array(
 		'path' => __FILE__,
@@ -69,4 +69,4 @@ define( 'SFS_VERSION', '1.3.0' );
 		$GLOBALS['sfgFormPrinter']->setInputTypeHook( 'SF_Select', '\SFS\SemanticFormsSelect::init', array() );
 	};
 
-// } );
+} );

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -14,17 +14,6 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once( __DIR__ . '/vendor/autoload.php' );
 }
 
-// A workaround to stay compatible with the 3.4.x release.
-if ( defined( 'SMW_VERSION' ) ) {
-	$GLOBALS['wgExtensionFunctions'][] = function() {
-		// This global variable is needed so that other extensions can
-		// hook into it to add their own input types.
-		$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
-	};
-} else {
-	$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
-}
-
 if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -14,6 +14,10 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once( __DIR__ . '/vendor/autoload.php' );
 }
 
+if ( file_exists( __DIR__ . '/../extensions/SemanticForms/SemanticForms.php' ) ) {
+	require_once( __DIR__ . '/../extensions/SemanticForms/SemanticForms.php' );
+}
+
 if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -14,6 +14,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once( __DIR__ . '/vendor/autoload.php' );
 }
 
+
 if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -14,8 +14,15 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once( __DIR__ . '/vendor/autoload.php' );
 }
 
-if ( file_exists( __DIR__ . '/../extensions/SemanticForms/SemanticForms.php' ) ) {
-	require_once( __DIR__ . '/../extensions/SemanticForms/SemanticForms.php' );
+// A workaround to stay compatible with the 3.4.x release.
+if ( defined( 'SMW_VERSION' ) ) {
+	$GLOBALS['wgExtensionFunctions'][] = function() {
+		// This global variable is needed so that other extensions can
+		// hook into it to add their own input types.
+		$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
+	};
+} else {
+	$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
 }
 
 if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -10,7 +10,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'This file is part of the SemanticFormsSelect extension, it is not a valid entry point.' );
 }
 
-if ( file_exists( __DIR__ . '/vendor/autoload.php' ) {
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once( __DIR__ . '/vendor/autoload.php' );
 }
 

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -10,8 +10,8 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'This file is part of the SemanticFormsSelect extension, it is not a valid entry point.' );
 }
 
-if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
-	require_once( __DIR__ . '/vendor/autoload.php' );
+if ( file_exists( __DIR__ . '/../../vendor/autoload.php' ) ) {
+	require_once( __DIR__ . '/../../vendor/autoload.php' );
 }
 
 if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -10,13 +10,19 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'This file is part of the SemanticFormsSelect extension, it is not a valid entry point.' );
 }
 
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) {
+	require_once( __DIR__ . '/vendor/autoload.php' );
+}
+
 if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }
 
-if ( !defined( 'SF_VERSION' ) || version_compare( SF_VERSION, '2.8', 'lt' ) ) {
-   die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );
-}
+$GLOBALS['wgExtensionFunctions'][] = function() {
+	if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
+		die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );
+	}
+};
 
 // Do not initialize more than once.
 if ( defined( 'SFS_VERSION' ) ) {

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -18,7 +18,6 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }
 
-
 $GLOBALS['wgExtensionFunctions'][] = function() {
 	if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
 		die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -18,7 +18,6 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }
 
-
 $GLOBALS['wgExtensionFunctions'][] = function() {
 	if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.26c', '<' ) ) {
 		if ( version_compare( SF_VERSION, '2.8', '<' ) ) {

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -10,8 +10,8 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	die( 'This file is part of the SemanticFormsSelect extension, it is not a valid entry point.' );
 }
 
-if ( file_exists( __DIR__ . '/../../vendor/autoload.php' ) ) {
-	require_once( __DIR__ . '/../../vendor/autoload.php' );
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once( __DIR__ . '/vendor/autoload.php' );
 }
 
 if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
@@ -25,17 +25,6 @@ $GLOBALS['wgExtensionFunctions'][] = function() {
 		}
 	}
 };
-
-// A workaround to stay compatible with the 3.4.x release.
-if ( defined( 'SMW_VERSION' ) ) {
-	$GLOBALS['wgExtensionFunctions'][] = function() {
-		// This global variable is needed so that other extensions can
-		// hook into it to add their own input types.
-		$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
-	};
-} else {
-	$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
-}
 
 // Do not initialize more than once.
 if ( defined( 'SFS_VERSION' ) ) {

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -18,17 +18,6 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }
 
-// A workaround to stay compatible with the 3.4.x release.
-if ( defined( 'SMW_VERSION' ) ) {
-	$GLOBALS['wgExtensionFunctions'][] = function() {
-		// This global variable is needed so that other extensions can
-		// hook into it to add their own input types.
-		$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
-	};
-} else {
-	$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
-}
-
 $GLOBALS['wgExtensionFunctions'][] = function() {
 	if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
 		die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -14,7 +14,6 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once( __DIR__ . '/vendor/autoload.php' );
 }
 
-
 if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -26,6 +26,17 @@ $GLOBALS['wgExtensionFunctions'][] = function() {
 	}
 };
 
+// A workaround to stay compatible with the 3.4.x release.
+if ( defined( 'SMW_VERSION' ) ) {
+	$GLOBALS['wgExtensionFunctions'][] = function() {
+		// This global variable is needed so that other extensions can
+		// hook into it to add their own input types.
+		$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
+	};
+} else {
+	$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
+}
+
 // Do not initialize more than once.
 if ( defined( 'SFS_VERSION' ) ) {
 	return 1;

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -66,8 +66,7 @@ call_user_func( function() {
 	);
 
 	$GLOBALS['wgExtensionFunctions'][] = function() {
-		$new = new SFFormPrinter;
-		$new->setInputTypeHook( 'SF_Select', '\SFS\SemanticFormsSelect::init', array() );
+		$GLOBALS['sfgFormPrinter']->setInputTypeHook( 'SF_Select', '\SFS\SemanticFormsSelect::init', array() );
 	};
 
 } );

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -18,6 +18,7 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }
 
+
 $GLOBALS['wgExtensionFunctions'][] = function() {
 	if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.26c', '<' ) ) {
 		if ( version_compare( SF_VERSION, '2.8', '<' ) ) {

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -19,7 +19,7 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 }
 
 $GLOBALS['wgExtensionFunctions'][] = function() {
-	if ( version_compare( SF_VERSION, '6.8', '<' ) ) {
+	if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
 		die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );
 	}
 };

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -20,14 +20,14 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 
 $GLOBALS['wgExtensionFunctions'][] = function() {
 	if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.26c', '<' ) ) {
-		if ( version_compare( 'SF_VERSION', '2.8', '<' ) ) {
+		if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
 			die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );
 		}
 	}
 };
 
 // A workaround to stay compatible with the 3.4.x release.
-/*if ( defined( 'SMW_VERSION' ) ) {
+if ( defined( 'SMW_VERSION' ) ) {
 	$GLOBALS['wgExtensionFunctions'][] = function() {
 		// This global variable is needed so that other extensions can
 		// hook into it to add their own input types.
@@ -35,7 +35,7 @@ $GLOBALS['wgExtensionFunctions'][] = function() {
 	};
 } else {
 	$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
-}*/
+}
 
 // Do not initialize more than once.
 if ( defined( 'SFS_VERSION' ) ) {

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -20,14 +20,14 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 
 $GLOBALS['wgExtensionFunctions'][] = function() {
 	if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.26c', '<' ) ) {
-		if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
+		if ( version_compare( 'SF_VERSION', '2.8', '<' ) ) {
 			die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );
 		}
 	}
 };
 
 // A workaround to stay compatible with the 3.4.x release.
-if ( defined( 'SMW_VERSION' ) ) {
+/*if ( defined( 'SMW_VERSION' ) ) {
 	$GLOBALS['wgExtensionFunctions'][] = function() {
 		// This global variable is needed so that other extensions can
 		// hook into it to add their own input types.
@@ -35,7 +35,7 @@ if ( defined( 'SMW_VERSION' ) ) {
 	};
 } else {
 	$GLOBALS['sfgFormPrinter'] = new StubObject( 'sfgFormPrinter', 'SFFormPrinter' );
-}
+}*/
 
 // Do not initialize more than once.
 if ( defined( 'SFS_VERSION' ) ) {

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -18,6 +18,7 @@ if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.23', 'lt' ) ) {
 	die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with MediaWiki 1.23 or above. You need to upgrade MediaWiki first.' );
 }
 
+
 $GLOBALS['wgExtensionFunctions'][] = function() {
 	if ( version_compare( SF_VERSION, '2.8', '<' ) ) {
 		die( '<b>Error:</b> This version of <a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">SemanticFormsSelect</a> is only compatible with Semantic Forms 2.8 or above. You need to upgrade <a href="https://www.mediawiki.org/wiki/Extension:Semantic_Forms">Semantic Forms</a> first.' );

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -66,7 +66,8 @@ call_user_func( function() {
 	);
 
 	$GLOBALS['wgExtensionFunctions'][] = function() {
-		$GLOBALS['sfgFormPrinter']->setInputTypeHook( 'SF_Select', '\SFS\SemanticFormsSelect::init', array() );
+		$new = new SFFormPrinter;
+		$new->setInputTypeHook( 'SF_Select', '\SFS\SemanticFormsSelect::init', array() );
 	};
 
 } );

--- a/SemanticFormsSelect.php
+++ b/SemanticFormsSelect.php
@@ -34,7 +34,7 @@ define( 'SFS_VERSION', '1.3.0' );
 /**
  * @codeCoverageIgnore
  */
-call_user_func( function() {
+// call_user_func( function() {
 
 	$GLOBALS['wgExtensionCredits']['semantic'][] = array(
 		'path' => __FILE__,
@@ -65,8 +65,8 @@ call_user_func( function() {
 		)
 	);
 
-	// $GLOBALS['wgExtensionFunctions'][] = function() {
+	$GLOBALS['wgExtensionFunctions'][] = function() {
 		$GLOBALS['sfgFormPrinter']->setInputTypeHook( 'SF_Select', '\SFS\SemanticFormsSelect::init', array() );
-	// };
+	};
 
-} );
+// } );

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,10 @@
 			"dev-master": "1.3.x-dev"
 		},
 		"installer-paths": {
-			"../../extensions/{$name}": ["mediawiki/semantic-forms"],
-			"../../extensions/{$name}": ["mediawiki/semantic-media-wiki"]
+			"../{$name}": [
+				"mediawiki/semantic-forms",
+				"mediawiki/semantic-media-wiki"
+			]
 		}
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,6 @@
 	"extra": {
 		"branch-alias": {
 			"dev-master": "1.3.x-dev"
-		},
-		"installer-paths": {
-			"../../extensions/{$name}": ["mediawiki/semantic-forms"]
 		}
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"php": ">=5.3.0",
 		"composer/installers": "1.*,>=1.0.1",
 		"mediawiki/semantic-media-wiki": ">=2.0",
-		"mediawiki/semantic-forms": ">=2.7,<3.5"
+		"mediawiki/semantic-forms": "dev-master"
 	},
 	"extra": {
 		"branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
 		"composer/installers": "1.*,>=1.0.1",
 		"mediawiki/semantic-media-wiki": ">=2.0",
 		"mediawiki/semantic-forms": "dev-master"
+
 	},
 	"extra": {
 		"branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
 			"dev-master": "1.3.x-dev"
 		},
 		"installer-paths": {
-			"../../extensions/{$name}": ["mediawiki/semantic-forms"]
+			"../../extensions/{$name}": ["mediawiki/semantic-forms"],
+			"../../extensions/{$name}": ["mediawiki/semantic-media-wiki"]
 		}
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
 		"composer/installers": "1.*,>=1.0.1",
 		"mediawiki/semantic-media-wiki": ">=2.0",
 		"mediawiki/semantic-forms": "dev-master"
-
 	},
 	"extra": {
 		"branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
 	"extra": {
 		"branch-alias": {
 			"dev-master": "1.3.x-dev"
+		},
+		"installer-paths": {
+			"../../extensions/{$name}": ["mediawiki/semantic-forms"]
 		}
 	},
 	"autoload": {

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -19,10 +19,11 @@ function installToMediaWikiRoot {
 
 	if [ "$SFS" != "" ]
 	then
-		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --dev --update-with-dependencies
+		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
 	else
 		composer init --stability dev
 		composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev --update-with-dependencies
+		composer require "mediawiki/semantic-forms:dev-master" --prefer-source --dev --update-with-dependencies
 
 		cd extensions
 		cd SemanticFormsSelect

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -27,7 +27,7 @@ function installToMediaWikiRoot {
 		cd extensions
 		cd SemanticFormsSelect
 
-composer update
+composer require "mediawiki/semantic-forms:dev-master" --prefer-source --dev --update-with-dependencies
 
 		# Pull request number, "false" if it's not a pull request
 		# After the install via composer an additional get fetch is carried out to

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -23,7 +23,7 @@ function installToMediaWikiRoot {
 	else
 composer update
 composer init --stability dev
-composer update "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
+composer install "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
 		cd extensions
 		cd SemanticFormsSelect
 composer update --dev

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -21,8 +21,8 @@ function installToMediaWikiRoot {
 	then
 		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
 	else
-		composer init
-		composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --update-with-dependencies
+		composer init --stability dev
+		composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev --update-with-dependencies
 
 		cd extensions
 		cd SemanticFormsSelect

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -21,13 +21,11 @@ function installToMediaWikiRoot {
 	then
 		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
 	else
-composer update
-composer init --stability dev
-composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
+		composer init --stability dev
+		composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev --update-with-dependencies
+
 		cd extensions
 		cd SemanticFormsSelect
-composer init --stability dev
-composer require "mediawiki/semantic-forms:dev-master" --prefer-source --dev
 
 		# Pull request number, "false" if it's not a pull request
 		# After the install via composer an additional get fetch is carried out to

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -22,6 +22,7 @@ function installToMediaWikiRoot {
 		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
 	else
 composer update
+composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
 		cd extensions
 		cd SemanticFormsSelect
 composer update --dev

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -23,7 +23,7 @@ function installToMediaWikiRoot {
 	else
 composer update
 composer init --stability dev
-composer install "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
+composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
 		cd extensions
 		cd SemanticFormsSelect
 composer update --dev

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -23,7 +23,7 @@ function installToMediaWikiRoot {
 	else
 composer update
 composer init --stability dev
-composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev --no-update
+composer update "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
 		cd extensions
 		cd SemanticFormsSelect
 composer update --dev

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -21,14 +21,9 @@ function installToMediaWikiRoot {
 	then
 		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
 	else
-		composer init --stability dev
-		composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev --update-with-dependencies
-
+composer update --dev
 		cd extensions
 		cd SemanticFormsSelect
-
-		composer init --stability dev
-composer require "mediawiki/semantic-forms:dev-master" --prefer-source --dev
 
 		# Pull request number, "false" if it's not a pull request
 		# After the install via composer an additional get fetch is carried out to

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -20,9 +20,11 @@ function installToMediaWikiRoot {
 	if [ "$SFS" != "" ]
 	then
 		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
+		composer update
 	else
 		composer init --stability dev
 		composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev --update-with-dependencies
+		composer update
 
 		cd extensions
 		cd SemanticFormsSelect

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -19,12 +19,10 @@ function installToMediaWikiRoot {
 
 	if [ "$SFS" != "" ]
 	then
-		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
-		composer update
+		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --dev --update-with-dependencies
 	else
 		composer init --stability dev
 		composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev --update-with-dependencies
-		composer update
 
 		cd extensions
 		cd SemanticFormsSelect

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -22,6 +22,7 @@ function installToMediaWikiRoot {
 		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
 	else
 composer update
+composer init --dev
 composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
 		cd extensions
 		cd SemanticFormsSelect

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -23,7 +23,7 @@ function installToMediaWikiRoot {
 	else
 composer update
 composer init --stability dev
-composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
+composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --no-update --dev
 		cd extensions
 		cd SemanticFormsSelect
 composer update --dev

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -22,7 +22,7 @@ function installToMediaWikiRoot {
 		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
 	else
 composer update
-composer init --dev
+composer init --stability dev
 composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
 		cd extensions
 		cd SemanticFormsSelect

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -26,7 +26,8 @@ composer init --stability dev
 composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev
 		cd extensions
 		cd SemanticFormsSelect
-composer update --dev
+composer init --stability dev
+composer require "mediawiki/semantic-forms:dev-master" --prefer-source --dev
 
 		# Pull request number, "false" if it's not a pull request
 		# After the install via composer an additional get fetch is carried out to

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -21,9 +21,10 @@ function installToMediaWikiRoot {
 	then
 		composer require 'mediawiki/semantic-forms-select='$SMT --prefer-source --update-with-dependencies
 	else
-composer update --dev
+composer update
 		cd extensions
 		cd SemanticFormsSelect
+composer update --dev
 
 		# Pull request number, "false" if it's not a pull request
 		# After the install via composer an additional get fetch is carried out to

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -27,6 +27,7 @@ function installToMediaWikiRoot {
 		cd extensions
 		cd SemanticFormsSelect
 
+		composer init --stability dev
 composer require "mediawiki/semantic-forms:dev-master" --prefer-source --dev
 
 		# Pull request number, "false" if it's not a pull request

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -27,7 +27,7 @@ function installToMediaWikiRoot {
 		cd extensions
 		cd SemanticFormsSelect
 
-composer require "mediawiki/semantic-forms:dev-master" --prefer-source --dev --update-with-dependencies
+composer require "mediawiki/semantic-forms:dev-master" --prefer-source --dev
 
 		# Pull request number, "false" if it's not a pull request
 		# After the install via composer an additional get fetch is carried out to

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -23,7 +23,7 @@ function installToMediaWikiRoot {
 	else
 composer update
 composer init --stability dev
-composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --no-update --dev
+composer require "mediawiki/semantic-forms-select:dev-master" --prefer-source --dev --no-update
 		cd extensions
 		cd SemanticFormsSelect
 composer update --dev

--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -27,6 +27,8 @@ function installToMediaWikiRoot {
 		cd extensions
 		cd SemanticFormsSelect
 
+composer update
+
 		# Pull request number, "false" if it's not a pull request
 		# After the install via composer an additional get fetch is carried out to
 		# update th repository to make sure that the latests code changes are


### PR DESCRIPTION
Due to changes done in SemanticForms which add support for extension.json we need to have a workaround for now since currently in SemanticForms that is set in a callback so it won't work since we load the extension after this one here. 

