### PR TITLE
Trigger input change when there is only one value (fixes #31)

### DIFF
--- a/res/scriptSelect.js
+++ b/res/scriptSelect.js
@@ -123,7 +123,7 @@ function SFSelect_setDependentValues (nameobj, fobj, values){
 			if (fobj.selectrm && fobj.selecttemplate != fobj.valuetemplate&&fobj.selectismultiple){
 				jQuery(element).closest("div.multipleTemplateInstance").remove();
 			} else{
-				if (selectedValues.length!=0)
+				if (selectedValues.length!=0 || values.length === 1)
 					jQuery(element).trigger("change");
 			}
 		} else if (!SFSelect_arrayEqual(newselected, selectedValues)){


### PR DESCRIPTION
Hello,

Here is a simple fix for #31.
It triggers an input change if there is only one value so subsequent fields can also be loaded.
