### PR TITLE
Only use extension.json on mw 1.28+

### DIFF
--- a/tests/travis/install-semantic-forms-select.sh
+++ b/tests/travis/install-semantic-forms-select.sh
@@ -57,7 +57,11 @@ function updateConfiguration {
 		echo '$wgLanguageCode = "'$SITELANG'";' >> LocalSettings.php
 	fi
 
-	echo 'wfLoadExtension( "SemanticForms" );' >> LocalSettings.php
+	if ( version_compare( $GLOBALS['wgVersion'], '1.28c', '>' ) ) {
+		echo 'wfLoadExtension( "SemanticForms" );' >> LocalSettings.php
+	} else {
+		echo 'require_once __DIR__ . "/extensions/SemanticForms/SemanticForms.php";' >> LocalSettings.php
+	}
 
 	echo 'error_reporting(E_ALL| E_STRICT);' >> LocalSettings.php
 	echo 'ini_set("display_errors", 1);' >> LocalSettings.php


### PR DESCRIPTION
manifest 2 will fail on 1.27 or lower so for now use it only on mw 1.28 and make 1.27 and lower fallback onto the old php main entry point where it will stop 1.27 loading extension.json.

It is fixed in PageForms since it goes back down to manifest 1.

See https://github.com/SemanticMediaWiki/SemanticFormsSelect/pull/38 which i doint know require any other changes or if they will break something.

This patch here will be the quicker one to fix it for now (temp solution until the real fix in https://github.com/SemanticMediaWiki/SemanticFormsSelect/pull/38 is merged)