### PR TITLE
Fixed static query case 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Semantic Forms Select (a.k.a. SFS) can generate a select form element with value
 
 ## Requirements
 
-- PHP 5.5 or later
+- PHP 5.6 or later
 - MediaWiki 1.27 or later
-- [Semantic MediaWiki][smw] 2.3 or later
-- [Page Forms][pf] 4.0.2 and 4.1.0
+- [Semantic MediaWiki][smw] 2.5 or later
+- [Page Forms][pf] 4.0.2 or later
 
 ## Installation
 
@@ -22,7 +22,7 @@ The recommended way to install Semantic Forms Select is by using [Composer][comp
 ```json
 {
 	"require": {
-		"mediawiki/semantic-forms-select": "~2.1"
+		"mediawiki/semantic-forms-select": "~3.0"
 	}
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,10 @@
 		{
 			"name": "Alexander Gesinn",
 			"role": "Developer"
+		},
+		{
+			"name": "Felix Ashu",
+			"role": "Developer"
 		}
 	],
 	"require": {

--- a/src/ApiSemanticFormsSelectRequestProcessor.php
+++ b/src/ApiSemanticFormsSelectRequestProcessor.php
@@ -73,27 +73,30 @@ class ApiSemanticFormsSelectRequestProcessor {
 		return json_decode( $json );
 	}
 
-	private function doProcessQueryFor( $query, $sep = "," ) {
+	private function doProcessQueryFor( $querystr, $sep = "," ) {
 
-		$query = str_replace(
+		$querystr = str_replace(
 			[ "&lt;", "&gt;", "sep=;" ],
 			[ "<", ">", "sep={$sep};" ],
-			$query
+			$querystr
 		);
 
-		$params = explode( ";", $query );
-		$f = str_replace( ";", "|", $params[0] );
+		$rawparams = explode( ";", $querystr );
+		$f = str_replace( ";", "|", $rawparams[0] );
 
-		$params[0] = $this->parser->replaceVariables( $f );
+		$rawparams[0] = $this->parser->replaceVariables( $f );
 
 		if ( $this->debugFlag ) {
-			error_log( implode( "|", $params ) );
+			error_log( implode( "|", $rawparams ) );
 		}
 
-		$values = $this->getFormattedValuesFrom(
-			$sep,
-			QueryProcessor::getResultFromFunctionParams( $params, SMW_OUTPUT_WIKI )
-		);
+		
+		list( $query, $params ) = QueryProcessor::getQueryAndParamsFromFunctionParams( $rawparams, SMW_OUTPUT_WIKI, QueryProcessor::INLINE_QUERY, false );
+			
+		$result = QueryProcessor::getResultFromQuery( $query, $params, SMW_OUTPUT_WIKI, QueryProcessor::INLINE_QUERY );
+		
+		
+		$values = $this->getFormattedValuesFrom( $sep, $result );
 
 		return json_encode( [
 			"values" => $values,


### PR DESCRIPTION
This pull request is fixing query cases with no ```@@@@``` dependencies (static ones). 

https://sandbox.semantic-mediawiki.org/wiki/Sp%C3%A9cial:AjouterDonn%C3%A9es/DemoStatic (not working now first field)

I also replaced ```SMWQueryProcessor::getResultFromFunctionParams``` because it might become eventually deprecated https://doc.semantic-mediawiki.org/classSMWQueryProcessor.html

Some minor other things added to README.md and composer.json.