### PR TITLE
Replace use of Parser::$mOutput, deprecated in 1.35

### DIFF
--- a/src/ApiSemanticFormsSelect.php
+++ b/src/ApiSemanticFormsSelect.php
@@ -27,7 +27,7 @@ class ApiSemanticFormsSelect extends ApiBase {
 		$parser = $this->getParser();
 		$parser->setTitle( Title::newFromText( 'NO TITLE' ) );
 		$parser->mOptions = new ParserOptions();
-		$parser->mOutput = new ParserOutput();
+		$parser->resetOutput();
 
 		$apiRequestProcessor = new \SFS\ApiSemanticFormsSelectRequestProcessor( $parser );
 		$apiRequestProcessor->setDebugFlag( $GLOBALS['wgSF_Select_debug'] );

--- a/tests/phpunit/Unit/SelectFieldTest.php
+++ b/tests/phpunit/Unit/SelectFieldTest.php
@@ -255,8 +255,7 @@ class SelectFieldTest extends \PHPUnit_Framework_TestCase {
 		$this->parser = $GLOBALS['wgParser'];
 		$this->parser->setTitle( Title::newFromText( 'NO TITLE' ) );
 		$this->parser->mOptions = new ParserOptions();
-		$this->parser->mOutput = new ParserOutput(
-		);  // Stored result thats passed back to Parser Object
+		$this->parser->resetOutput();
 		$this->parser->clearState();
 		$this->SelectField = new SelectField( $this->parser );
 	}


### PR DESCRIPTION
The typical replacement, Parser::getOutput(), has been in MediaWiki
for over a decade (since 1.12.2 in 2008).

In this case, the extension wants to reset $mOutput, which is done
via the Parser::resetOutput() function but isn't really necessary
to do at all.

Bug: T275160