### PR TITLE
Maintenance: use JSON.parse instead of $.parseJSON

### DIFF
--- a/res/scriptSelect.js
+++ b/res/scriptSelect.js
@@ -215,7 +215,7 @@ function SFSelect_arrayEqual(a, b) {
      */
 
         // get the objects from PHP using mw.config helper
-    var SFSelect_fobjs = $.parseJSON(mw.config.get('sf_select'));
+    var SFSelect_fobjs = JSON.parse(mw.config.get('sf_select'));
 
     /**
      * changeHandler


### PR DESCRIPTION
As recommended by JQMIGRATE. According to [caniuse](https://caniuse.com/mdn-javascript_builtins_json_parse), JSON.parse is compatible with IE8+, Firefox 3.5+, Chrome 4+, Safari 4+, Opera 11.5+.

This removes one <s>spam</s> console line emitted by JQMIGRATE.