### PR TITLE
Fix issue with select2 for PF 4.9+

### DIFF
--- a/res/scriptSelect.js
+++ b/res/scriptSelect.js
@@ -235,7 +235,7 @@ function SFSelect_arrayEqual(a, b) {
         var select2enabled = false;
         var name = src.name;
 
-        if (typeof selectElement.select2 === "function") { 
+        if (typeof selectElement.select2 === "function" && selectElement.hasClass('select2-hidden-accessible')) {
             // safe to use the function
 
             var select2Data = selectElement.select2('data');


### PR DESCRIPTION
As documented by select2 docs:
https://select2.org/programmatic-control/methods#checking-if-the-plugin-is-initialized

Tested and it works with PageForms 4.6 and current master (after 5.1) on a MediaWiki 1.33.0 + Semantic MediaWiki 3.1.3. I reproduced partly the forms [DemoStatic](https://sandbox.semantic-mediawiki.org/wiki/Sp%C3%A9cial:AjouterDonn%C3%A9es/DemoStatic) and [DemoAjax1](https://sandbox.semantic-mediawiki.org/wiki/Sp%C3%A9cial:AjouterDonn%C3%A9es/DemoAjax1) from sandbox.

Fixes: #82