### PR TITLE
Mobile compatibility

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -46,7 +46,11 @@
 				"ext.pageforms.main",
 				"ext.pageforms.select2"
 			],
-			"position": "bottom"
+			"position": "bottom",
+			"targets": [
+				"desktop",
+				"mobile"
+			]
 		}
 	},
 	"ResourceFileModulePaths": {


### PR DESCRIPTION
If anyone wants to use SemanticFormsSelect with MobileFrontend, this patch enable the main SemanticFormsSelect script on mobile.
(You will also need to apply https://github.com/wikimedia/mediawiki-extensions-PageForms/pull/10.)