### PR TITLE
Don't add change event before DOM is ready

### DIFF
--- a/res/scriptSelect.js
+++ b/res/scriptSelect.js
@@ -451,40 +451,42 @@ function SFSelect_arrayEqual(a, b) {
     //simplify duplicated object.
     SFSelect_fobjs = SFSelect_removeDuplicateFobjs(SFSelect_fobjs);
 
-    // register change handler
-    $("form#pfForm").change(function (event) {
-        SFSelect_changeHandler(event.target);
-    });
+    $(document).ready(function () {
+        // register change handler
+        $("form#pfForm").change(function (event) {
+            SFSelect_changeHandler(event.target);
+        });
 
-    var objs = null;
+        var objs = null;
 
-    // populate Select fields at load time
-    for (var i = 0; i < SFSelect_fobjs.length; i++) {
+        // populate Select fields at load time
+        for (var i = 0; i < SFSelect_fobjs.length; i++) {
 
-        var fobj = SFSelect_fobjs[i];
+            var fobj = SFSelect_fobjs[i];
 
-        //var valuepat = "input[name='" + fobj.valuetemplate + "\\["+ fobj.valuefield + "\\]']";
+            //var valuepat = "input[name='" + fobj.valuetemplate + "\\["+ fobj.valuefield + "\\]']";
 
-        // support multi instance templates: select all "input" items starting with fobj.valuetemplate
-        // and containing fobj.valuefield
-        // example name attribute: name="myTemplate[0a][myField]"
-        var valuepat = 'input[name^="' + fobj.valuetemplate + '"]' + '[name*="' + fobj.valuefield + '"]';
-
-        if ($(valuepat).val()) {
-            // get Select fields, skipping 'map_fields'
-            objs = jQuery(valuepat).not('input[name*=map_field]');
-        } else {
-            //valuepat= "select[name='" + fobj.valuetemplate + "\\["+ fobj.valuefield + "\\]']";
-
-            // support multi instance templates: select all "select" items starting with fobj.valuetemplate
+            // support multi instance templates: select all "input" items starting with fobj.valuetemplate
             // and containing fobj.valuefield
             // example name attribute: name="myTemplate[0a][myField]"
-            var valuepat = 'select[name^="' + fobj.valuetemplate + '"]' + '[name*="' + fobj.valuefield + '"]';
+            var valuepat = 'input[name^="' + fobj.valuetemplate + '"]' + '[name*="' + fobj.valuefield + '"]';
 
-            objs = jQuery(valuepat).not('select[name*=map_field]');
+            if ($(valuepat).val()) {
+                // get Select fields, skipping 'map_fields'
+                objs = jQuery(valuepat).not('input[name*=map_field]');
+            } else {
+                //valuepat= "select[name='" + fobj.valuetemplate + "\\["+ fobj.valuefield + "\\]']";
+
+                // support multi instance templates: select all "select" items starting with fobj.valuetemplate
+                // and containing fobj.valuefield
+                // example name attribute: name="myTemplate[0a][myField]"
+                var valuepat = 'select[name^="' + fobj.valuetemplate + '"]' + '[name*="' + fobj.valuefield + '"]';
+
+                objs = jQuery(valuepat).not('select[name*=map_field]');
+            }
+            objs.trigger("change");
         }
-        objs.trigger("change");
-    }
+    });
 
 //}( jQuery, mediaWiki ) );
 }(jQuery) );


### PR DESCRIPTION
We are using SFS 3 and noticed that sometimes the change event would not trigger on select elements (especially on slow networks).
This seems to happen because the JS can be executed before the DOM is ready so `$("form#pfForm")` does not return anything.

This patch adds a DOM ready event around this part of the code.

I see that master is now the 4.0 beta so I'm not sure if you are still accepting patches for 3.0?