### PR TITLE
Bug fix - failing CI test for MW 1.39

### DIFF
--- a/.env-39
+++ b/.env-39
@@ -1,0 +1,4 @@
+MW_VERSION?=1.39
+PHP_VERSION?=8.1
+DB_TYPE?=mysql
+DB_IMAGE?="mariadb:latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,13 @@ jobs:
             database_image: "mariadb:latest"
             coverage: false
             experimental: true
-          - mediawiki_version: '1.40'
-            smw_version: dev-master
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:latest"
-            coverage: false
-            experimental: true
+          # - mediawiki_version: '1.40'
+          #   smw_version: dev-master
+          #   php_version: 8.1
+          #   database_type: mysql
+          #   database_image: "mariadb:latest"
+          #   coverage: false
+          #   experimental: true
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
--include .env
+-include .env-39
 export
 
 # setup for docker-compose-ci build directory

--- a/src/ApiSemanticFormsSelectRequestProcessor.php
+++ b/src/ApiSemanticFormsSelectRequestProcessor.php
@@ -64,6 +64,10 @@ class ApiSemanticFormsSelectRequestProcessor {
 			throw new InvalidArgumentException( 'Missing an query parameter' );
 		}
 
+		if ( !isset( $parameters['query'] ) || !isset( $parameters['sep'] ) ) {
+			throw new InvalidArgumentException( 'Missing an query parameter' );
+		}
+
 		$this->parser->firstCallInit();
 		$json = [];
 
@@ -147,7 +151,7 @@ class ApiSemanticFormsSelectRequestProcessor {
 
 	private function getFormattedValuesFrom( $sep, $values ) {
 
-		if ( strpos( $values, $sep ) === false ) {
+		if ( strpos( $values ?? '', $sep ) === false ) {
 			return [ $values ];
 		}
 

--- a/src/SelectField.php
+++ b/src/SelectField.php
@@ -40,7 +40,7 @@ class SelectField {
 	/**
 	 * Convenience function to process all parameters at once
 	 */
-	public function processParameters( $input_name = "", $other_args ) {
+	public function processParameters( $other_args, $input_name = "" ) {
 		if ( array_key_exists( "query", $other_args ) ) {
 			$this->setQuery( $other_args );
 		} elseif ( array_key_exists( "function", $other_args ) ) {

--- a/src/SemanticFormsSelectInput.php
+++ b/src/SemanticFormsSelectInput.php
@@ -54,8 +54,8 @@ class SemanticFormsSelectInput extends PFFormInput {
 	 * This is currently just a wrapper for getHTML().
 	 */
 	public function getHtmlText() {
-		return self::getHTML( $this->mCurrentValue, $this->mInputName, $this->mIsMandatory, $this->mIsDisabled,
-			$this->mOtherArgs );
+		return self::getHTML( $this->mIsMandatory, $this->mIsDisabled,
+			$this->mOtherArgs, $this->mCurrentValue, $this->mInputName );
 	}
 
 	/**
@@ -69,7 +69,7 @@ class SemanticFormsSelectInput extends PFFormInput {
 	 * @param    string[] $other_args Array of other field parameters
 	 * @return string
 	 */
-	public function getHTML( $cur_value = "", $input_name = "", $is_mandatory, $is_disabled, Array $other_args ) {
+	public function getHTML( $is_mandatory, $is_disabled, Array $other_args, $cur_value = "", $input_name = "" ) {
 		global $wgPageFormsFieldNum, $wgUser;
 
 		// shortcut to the SelectField object

--- a/tests/phpunit/Unit/SelectFieldTest.php
+++ b/tests/phpunit/Unit/SelectFieldTest.php
@@ -38,7 +38,7 @@ class SelectFieldTest extends \PHPUnit_Framework_TestCase {
 	public function testProcessParameters_Query() {
 
 		$this->selectField->processParameters(
-			"", $this->other_args_query_parametrized
+			$this->other_args_query_parametrized, ""
 		);
 		$this->assertTrue(
 			array_key_exists( "query", $this->other_args_query_parametrized )
@@ -48,7 +48,7 @@ class SelectFieldTest extends \PHPUnit_Framework_TestCase {
 	public function testProcessParameters_Function() {
 
 		$this->selectField->processParameters(
-			"", $this->other_args_function_parametrized
+			$this->other_args_function_parametrized, ""
 		);
 		$this->assertArrayHasKey(
 			"function", $this->other_args_function_parametrized
@@ -250,10 +250,23 @@ class SelectFieldTest extends \PHPUnit_Framework_TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
+		$user = $this->getMockBuilder( 'MediaWiki\User\UserIdentity' )
+			->disableOriginalConstructor()
+			->getMock();
+		$name = $user->getName();
+		$parserOption;
+
+		if ( version_compare( MW_VERSION, '1.39', '>=' ) ) {
+			//check if version is higher than 1.39, or the same (the getOption() function within ParserOptions is different then in MW 1.35)
+			$parserOption = new ParserOptions( $user );
+		} else {
+			//if MW version is lower than 1.39
+			$parserOption = new ParserOptions( $name );
+		}
 		$parser = MediaWikiServices::getInstance()->getParser();
 		$parser->setOutputType(Parser::OT_HTML);
 		$parser->setTitle( Title::newFromText( 'NO TITLE' ) );
-		$parser->mOptions = new ParserOptions();
+		$parser->setOptions($parserOption);
 		$parser->resetOutput();
 		$parser->clearState();
 		$this->selectField = new SelectField( $parser );


### PR DESCRIPTION
Add changes to test files in order to run CI test for **MW 1.39** sucessfully. Files inside **src** directory refactored to fix deprecation warnings. 