### PR TITLE
Remove mw 1.35 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,23 +21,23 @@ jobs:
             smw_version: '4.2.0'
             php_version: 8.1
             database_type: mysql
-            database_image: "mariadb:latest"
+            database_image: "mariadb:11.2"
             coverage: false
             experimental: false
           - mediawiki_version: '1.39'
             smw_version: dev-master
             php_version: 8.1
             database_type: mysql
-            database_image: "mariadb:latest"
+            database_image: "mysql:8"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.40'
+            smw_version: '4.2.0'
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mariadb:11.2"
             coverage: true
             experimental: false
-          # - mediawiki_version: '1.40'
-          #   smw_version: dev-master
-          #   php_version: 8.1
-          #   database_type: mysql
-          #   database_image: "mariadb:latest"
-          #   coverage: false
-          #   experimental: true
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.39'
+            smw_version: '4.2.0'
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mariadb:latest"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.39'
             smw_version: dev-master
             php_version: 8.1
             database_type: mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,27 +17,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.35'
-            smw_version: '4.1.2'
-            php_version: 7.4
-            database_type: mysql
-            database_image: "mysql:5.7"
-            coverage: true
-            experimental: false
-          - mediawiki_version: '1.35'
-            smw_version: dev-master
-            php_version: 7.4
-            database_type: mysql
-            database_image: "mysql:5.7"
-            coverage: false
-            experimental: false
           - mediawiki_version: '1.39'
             smw_version: dev-master
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:latest"
-            coverage: false
-            experimental: true
+            coverage: true
+            experimental: false
           # - mediawiki_version: '1.40'
           #   smw_version: dev-master
           #   php_version: 8.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,8 @@ jobs:
         if: matrix.coverage == true
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/php/coverage.xml
         if: matrix.coverage == true

--- a/extension.json
+++ b/extension.json
@@ -14,7 +14,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.35"
+		"MediaWiki": ">= 1.39"
 	},
 	"AutoloadClasses": {
 		"SFS\\Hooks": "SemanticFormsSelect.hooks.php",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,9 +16,6 @@
         <testsuite name="semantic-forms-select-unit">
             <directory>tests/phpunit/Unit</directory>
         </testsuite>
-        <testsuite name="semantic-forms-select-integration">
-            <directory>tests/phpunit/Integration</directory>
-        </testsuite>
     </testsuites>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
* Test against MW 1.40 and promote it to run coverage.
* Bump MW requirement to 1.39.
* Remove non-existent integration from phpunit. The folder doesn't exist and nor do the tests.
* Update codecov/codecov-action to v4