### PR TITLE
Add tests for MW 1.41, 1.42 and 1.43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,27 @@ jobs:
             database_image: "mariadb:11.2"
             coverage: true
             experimental: false
+          - mediawiki_version: '1.41'
+            smw_version: dev-master
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.42'
+            smw_version: dev-master
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.43'
+            smw_version: dev-master
+            php_version: 8.1
+            database_type: mysql
+            database_image: "mariadb:11.2"
+            coverage: false
+            experimental: false
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         include:
           - mediawiki_version: '1.39'
             smw_version: '4.2.0'
+            pf_version: '5.9'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
@@ -26,6 +27,7 @@ jobs:
             experimental: false
           - mediawiki_version: '1.39'
             smw_version: dev-master
+            pf_version: '5.9'
             php_version: 8.1
             database_type: mysql
             database_image: "mysql:8"
@@ -33,6 +35,7 @@ jobs:
             experimental: false
           - mediawiki_version: '1.40'
             smw_version: '4.2.0'
+            pf_version: '5.9'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
@@ -40,6 +43,7 @@ jobs:
             experimental: false
           - mediawiki_version: '1.41'
             smw_version: dev-master
+            pf_version: '5.9'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
@@ -47,6 +51,7 @@ jobs:
             experimental: false
           - mediawiki_version: '1.42'
             smw_version: dev-master
+            pf_version: '5.9'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
@@ -54,6 +59,7 @@ jobs:
             experimental: false
           - mediawiki_version: '1.43'
             smw_version: dev-master
+            pf_version: '5.9'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
@@ -63,6 +69,7 @@ jobs:
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}
       SMW_VERSION: ${{ matrix.smw_version }}
+      PF_VERSION: ${{ matrix.pf_version }}
       PHP_VERSION: ${{ matrix.php_version }}
       DB_TYPE: ${{ matrix.database_type }}
       DB_IMAGE: ${{ matrix.database_image }}

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DB_IMAGE?=""
 
 # extensions
 SMW_VERSION?=4.1.2
-PF_VERSION?=5.5.1
+PF_VERSION?=5.9
 
 # composer
 # Enables "composer update" inside of extension

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
 		"php": ">=7.3",
 		"composer/installers": "1.*,>=1.0.1",
 		"mediawiki/semantic-media-wiki": "~3.0|~4.0|~5.0",
-		"mediawiki/page-forms": ">=5.3.0"
+		"mediawiki/page-forms": ">=5.9.0"
 	},
 	"require-dev": {
 		"mediawiki/semantic-media-wiki": "@dev"

--- a/tests/phpunit/Unit/ApiSemanticFormsSelectRequestProcessorTest.php
+++ b/tests/phpunit/Unit/ApiSemanticFormsSelectRequestProcessorTest.php
@@ -18,7 +18,7 @@ use FauxRequest;
  * @author  FelixAba
  */
 class ApiSemanticFormsSelectRequestProcessorTest
-	extends \PHPUnit_Framework_TestCase {
+	extends \PHPUnit\Framework\TestCase {
 
 	private $ApiSFSRP;
 

--- a/tests/phpunit/Unit/ApiSemanticFormsSelectTest.php
+++ b/tests/phpunit/Unit/ApiSemanticFormsSelectTest.php
@@ -17,7 +17,7 @@ use FauxRequest;
  *
  * @author  mwjames
  */
-class ApiSemanticFormsSelectTest extends \PHPUnit_Framework_TestCase {
+class ApiSemanticFormsSelectTest extends \PHPUnit\Framework\TestCase {
 
 	private $ApiSFS;
 	private $ApiMain;

--- a/tests/phpunit/Unit/OutputTest.php
+++ b/tests/phpunit/Unit/OutputTest.php
@@ -13,7 +13,7 @@ use SFS\Output;
  *
  * @author  mwjames
  */
-class OutputTest extends \PHPUnit_Framework_TestCase {
+class OutputTest extends \PHPUnit\Framework\TestCase {
 	private $data;
 
 	protected function setUp(): void {

--- a/tests/phpunit/Unit/SelectFieldTest.php
+++ b/tests/phpunit/Unit/SelectFieldTest.php
@@ -20,7 +20,7 @@ use Title;
  * @group  semantic-forms-select
  * @author FelixAba
  */
-class SelectFieldTest extends \PHPUnit_Framework_TestCase {
+class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	private $selectField;
 	
 	private $other_args_query_parametrized = [ 'query' => '((Category:Building Complex))((Part Of Site::@@@@));?Display Title;format~list;sort~Display Title;sep~,;link~none;headers~hide;limit~500' ];

--- a/tests/phpunit/Unit/SemanticFormsSelectInputTest.php
+++ b/tests/phpunit/Unit/SemanticFormsSelectInputTest.php
@@ -13,7 +13,7 @@ use SFS\SemanticFormsSelectInput;
  *
  * @author  FelixAba
  */
-class SemanticFormsSelectInputTest extends \PHPUnit_Framework_TestCase {
+class SemanticFormsSelectInputTest extends \PHPUnit\Framework\TestCase {
 
 	private $SFSInput;
 


### PR DESCRIPTION
* Updates PageForm to 5.9 due to issues with 5.3/5.5. 5.9 supports MW 1.39+.
* Fix tests for MW 1.43. Replace PHPUnit_Framework_TestCase with \PHPUnit\Framework\TestCase.