### PR TITLE
Issue-134 - handle HTML-formatted SMW values in select field comparison

### DIFF
--- a/src/SemanticFormsSelectInput.php
+++ b/src/SemanticFormsSelectInput.php
@@ -191,6 +191,15 @@ class SemanticFormsSelectInput extends PFFormInput {
 
 					} else {
 
+						// Check if $val contains a long HTML-formatted string instead of a raw value.
+						// If so, extract the actual value from within the <span class="smw-value"> tag.
+						if ( strpos( $val, '<span class="smw-value">' ) !== false ) {
+							preg_match( '/<span class="smw-value">(.*?)<\/span>/', $val, $matches );
+							if ( isset( $matches[1] ) ) {
+								$val = $matches[1];
+							}
+						}
+
 						if ( in_array( $val, $curvalues ) ) {
 							$selected = " selected='selected'";
 						}


### PR DESCRIPTION
This PR is related to the issue #134.

This PR contains:

- Additional check if a value is wrapped in <span class="smw-value"> and extract the actual raw value before comparison. This prevents previously selected values from being lost when editing the form again.