### PR TITLE
Init $ot and $mIncludeSizes properties

### DIFF
--- a/src/ApiSemanticFormsSelectRequestProcessor.php
+++ b/src/ApiSemanticFormsSelectRequestProcessor.php
@@ -69,6 +69,8 @@ class ApiSemanticFormsSelectRequestProcessor {
 		}
 
 		$this->parser->firstCallInit();
+		$this->parser->clearState();
+		$this->parser->setOutputType(Parser::OT_HTML);
 		$json = [];
 
 		if ( isset( $parameters['approach'] ) && $parameters['approach'] == 'smw' ) {


### PR DESCRIPTION
Fixes https://github.com/SemanticMediaWiki/SemanticFormsSelect/issues/139.

`clearState()` is marked as internal so I'm not sure it is correct to call it, but without it I get this error:
```
[0a7f3b254b7d7ec5f2fc07a1] Exception caught: Typed property MediaWiki\\Parser\\Parser::$mIncludeSizes must not be accessed before initialization
```