### PR TITLE
Initialize the API parser via Parser::startExternalParse()

### DIFF
--- a/src/ApiSemanticFormsSelect.php
+++ b/src/ApiSemanticFormsSelect.php
@@ -93,9 +93,19 @@ class ApiSemanticFormsSelect extends ApiBase {
 	 */
 	protected function getParser(): Parser {
 		$parser = MediaWikiServices::getInstance()->getParserFactory()->create();
-		$parser->setTitle( Title::newFromText( 'NO TITLE' ) );
-		$parser->setOptions( new ParserOptions( $this->getUser() ) );
-		$parser->resetOutput();
+
+		// The request processor uses Parser::replaceVariables() directly rather
+		// than a full parse, so the parser must be put into a usable state first.
+		// startExternalParse() is the supported public entry point for this: it
+		// sets the page and options, sets the output type, and clears parser
+		// state. Without it, properties such as Parser::$ot and
+		// Parser::$mIncludeSizes are uninitialized and fatal under MW 1.43+
+		// (https://github.com/SemanticMediaWiki/SemanticFormsSelect/issues/139).
+		$parser->startExternalParse(
+			Title::newFromText( 'NO TITLE' ),
+			new ParserOptions( $this->getUser() ),
+			Parser::OT_HTML
+		);
 
 		return $parser;
 	}

--- a/src/ApiSemanticFormsSelectRequestProcessor.php
+++ b/src/ApiSemanticFormsSelectRequestProcessor.php
@@ -68,9 +68,6 @@ class ApiSemanticFormsSelectRequestProcessor {
 			throw new InvalidArgumentException( 'Missing an query parameter' );
 		}
 
-		$this->parser->firstCallInit();
-		$this->parser->clearState();
-		$this->parser->setOutputType(Parser::OT_HTML);
 		$json = [];
 
 		if ( isset( $parameters['approach'] ) && $parameters['approach'] == 'smw' ) {


### PR DESCRIPTION
## Summary

Refactor of the parser initialization for the `sformsselect` API, following up on #140 (which fixed #139). Replaces the scattered, partly-`@internal` parser priming with a single supported public call.

## Background

The `sformsselect` API builds a standalone parser and calls `Parser::replaceVariables()` directly (not a full `parse()`). On MediaWiki 1.43+ several `Parser` properties became typed-without-default, so `replaceVariables()` → `braceSubstitution()` fatals with *"…must not be accessed before initialization"* unless the parser's output type and parse state are initialized first:

- `Parser::$ot` — set by `setOutputType()`
- `Parser::$mIncludeSizes` — set by `clearState()`

#140 fixed this by adding `firstCallInit()` + `clearState()` + `setOutputType()` inside `ApiSemanticFormsSelectRequestProcessor`. That works, but `clearState()` is `@internal` (the PR author flagged this), and parser setup ended up split across two classes.

## Change

`ApiSemanticFormsSelect::getParser()` now does a single call:

```php
$parser->startExternalParse(
    Title::newFromText( 'NO TITLE' ),
    new ParserOptions( $this->getUser() ),
    Parser::OT_HTML
);
```

`startExternalParse()` is the supported public entry point. It internally runs `setPage()` + assigns options + `setOutputType()` + `clearState()`, so it **subsumes** both the old `setTitle()`/`setOptions()`/`resetOutput()` trio *and* the priming added in #140 — which are all removed. (`clearState()` re-creates the same `ParserOutput` that `resetOutput()` did.) All parser setup now lives in one place; the request processor is a pure consumer.

`firstCallInit()` is dropped entirely: on MW 1.43 it is a documented **no-op** (its body says *"it no longer does anything"*). Parser functions — including SMW's `#ask`/`#show` — are registered via the `ParserFirstCallInit` **hook**, which the `Parser` constructor fires at `getParserFactory()->create()` time, so `{{#ask:…}}` still expands.

## Verification

- `php -l` clean on both files.
- Statically verified against the MW 1.43 core source: `startExternalParse()` signature/behavior, `Title` is-a `PageReference` (so the first arg is type-valid), and that the call initializes both `$ot` and `$mIncludeSizes`.
- Behaviorally equivalent to the post-#140 state (no lost/duplicated init; ordering has no observable effect; `getParser()` is the only production caller of the processor).
- CI exercises the runtime path (`ApiSemanticFormsSelectTest::testExecute`). A full local runtime run wasn't possible in my environment, so this is **draft** pending green CI.

## Out of scope (possible follow-up)

`SelectField::setFunction()` also calls `replaceVariables()` directly (on the shared global parser) with no explicit initialization, so it carries the same #139 exposure shape. Not addressed here — flagging for a separate look.

Refs #139.