### PR TITLE
Use a dedicated initialized parser in SemanticFormsSelectInput

### DIFF
--- a/src/SemanticFormsSelectInput.php
+++ b/src/SemanticFormsSelectInput.php
@@ -11,9 +11,12 @@
 
 namespace SFS;
 
+use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use SMWQueryProcessor as QueryProcessor;
 use Parser;
+use ParserOptions;
 use PFFormInput;
 use MWDebug;
 
@@ -31,9 +34,40 @@ class SemanticFormsSelectInput extends PFFormInput {
 	public function __construct( $inputNumber, $curValue, $inputName, $disabled, $otherArgs ) {
 		parent::__construct( $inputNumber, $curValue, $inputName, $disabled, $otherArgs );
 
-		// SelectField is a simple value object - we accept creating it in the constructor
-		$parser = MediaWikiServices::getInstance()->getParser();
+		// SelectField is a simple value object - we accept creating it in the constructor.
+		// Use a local variable: SelectField::__construct() takes the parser by
+		// reference, and passing a method return value directly would emit an
+		// "Only variables should be passed by reference" notice.
+		$parser = $this->newInitializedParser();
 		$this->mSelectField = new SelectField( $parser );
+	}
+
+	/**
+	 * Create a dedicated, fully-initialized parser for SelectField.
+	 *
+	 * SelectField (for the "function=" parameter) calls Parser::replaceVariables()
+	 * directly. That requires a parser whose output type and parse state are
+	 * already initialized, otherwise typed properties such as Parser::$ot and
+	 * Parser::$mIncludeSizes are accessed before initialization and fatal under
+	 * MW 1.43+ (cf. issue #139, which fixed the equivalent path in the
+	 * sformsselect API).
+	 *
+	 * The shared global parser (MediaWikiServices::getParser()) must NOT be used
+	 * here: if it has not started a parse it is uninitialized, and if it is
+	 * mid-parse calling replaceVariables() on it re-entrantly would corrupt that
+	 * parse. Use a separate instance primed via startExternalParse() instead.
+	 *
+	 * @return Parser
+	 */
+	private function newInitializedParser(): Parser {
+		$parser = MediaWikiServices::getInstance()->getParserFactory()->create();
+		$parser->startExternalParse(
+			Title::newFromText( 'NO TITLE' ),
+			new ParserOptions( RequestContext::getMain()->getUser() ),
+			Parser::OT_HTML
+		);
+
+		return $parser;
 	}
 
 	public static function getName() {


### PR DESCRIPTION
## Summary

Form-rendering counterpart to #139 / #147. `SelectField::setFunction()` — the `function=` form-field parameter — calls `Parser::replaceVariables('{{#…}}')` directly (SelectField.php:100). On MediaWiki 1.43+ that fatals with *"…must not be accessed before initialization"* unless the parser's output type (`$ot`) and parse state (`$mIncludeSizes`) are initialized first — the same class of bug fixed for the `sformsselect` API.

## The problem

`SemanticFormsSelectInput` handed `SelectField` the **shared global parser** via `MediaWikiServices::getInstance()->getParser()` (= `ParserFactory::getMainInstance()`). That's fragile in two ways on MW 1.43+:

- **Uninitialized:** `getMainInstance()` returns the parser as-is; until something parses with it, `$ot`/`$mIncludeSizes` are unset → `replaceVariables()` fatals (#139 shape).
- **Re-entrant:** if that shared instance is *mid-parse*, calling `replaceVariables()` on it re-enters the active parser and can corrupt the surrounding parse.

Core explicitly discourages this service for parsing (`ServiceWiring.php`, T343070). It hasn't been widely reported because the common `query=` path doesn't touch the parser at all (SelectField.php:73), and in many requests the shared parser happens to be initialized already — masking the bug.

## The change

Create a **dedicated** parser via `ParserFactory::create()` and prime it with `Parser::startExternalParse()`, mirroring the API fix. This fixes both failure modes: a private instance (no re-entrancy) that is fully initialized (`startExternalParse` → `setOutputType` sets `$ot`, `clearState` sets `$mIncludeSizes`).

## Verification

- `php -l` clean.
- Reviewed against MW 1.43 core + Page Forms 6.0/master source: `startExternalParse` initializes both typed properties; `Title` is-a `PageReference` (valid arg); `RequestContext::getMain()->getUser()` satisfies `ParserOptions`; and the new private `newInitializedParser()` does **not** collide with any `PFFormInput` method (checked PF 6.0 and master).
- CI-covered: `SemanticFormsSelectInputTest::testGetHTMLText` (with `function='Bar'`, Page Forms in the matrix) drives this exact path; the fix makes it deterministic rather than dependent on shared-parser state. (`{{#Bar}}` → `callParserFunction` returns `found=false` → no fatal.) Draft pending green CI.

## Known minor (possible follow-up)

The parser is created eagerly in the constructor, so the common `query=` path (which never uses the parser) also pays for a `create()` + `startExternalParse()`. Magnitude is small for typical forms; it could be made lazy (create only when `function=` is present), but that couples the constructor to render-time arg logic, so I left it as-is for review.

Refs #139. Independent of #147 (both branch from `master`).