### PR TITLE
Remove leftover .env-39 (MediaWiki 1.39 era)

### DIFF
--- a/.env-39
+++ b/.env-39
@@ -1,4 +1,0 @@
-MW_VERSION?=1.43
-PHP_VERSION?=8.1
-DB_TYPE?=mysql
-DB_IMAGE?="mariadb:latest"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
--include .env-39
 export
 
 # setup for docker-compose-ci build directory


### PR DESCRIPTION
## Summary

`.env-39` is a confirmed leftover from the MediaWiki 1.39 era and is safe to remove.

- **Origin:** added in `e5b85d7` (2024-05-27, *"Bug fix - failing CI test for MW 1.39"*), which also switched the Makefile from `-include .env` to `-include .env-39` to pin a 1.39 build.
- **Orphaned:** `90120e1` (2026-04-11) *"Add CI for MW 1.44-45 and remove MW 1.39-1.42"* dropped 1.39 from CI; six minutes later `806ea23` *"Update .env-39"* bumped the file's `MW_VERSION` 1.39 → 1.43 but left the misleading filename. It's been dead since.
- **No effect on CI:** referenced only by `Makefile:1` `-include .env-39`; all its assignments are soft (`?=`) and shadowed by the env vars the workflow already exports (matrix is 1.43/1.44/1.45). `-include` (leading dash) also means make ignores it when absent, so removal can't break the build.

This removes the file and the orphaned include line.

### Note (optional follow-up)
The 1.39 hack replaced the generic `-include .env` with `-include .env-39` back in 2024, which left `template.env` + the `.gitignore` `.env` entry orphaned (nothing has included `.env` since). I removed the include line outright to match the cleanup. If you'd prefer to re-activate the `template.env` → `.env` local-override flow instead, I can change the line to `-include .env` rather than deleting it — just say the word.

Draft pending CI (confirms `make ci` still runs without the include).