### PR TITLE
Support Semantic MediaWiki 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,42 +11,42 @@ jobs:
 
   test:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.experimental }}
 
     strategy:
       matrix:
         include:
           - mediawiki_version: '1.43'
-            smw_version: '6.0.1'
-            pf_version: '6.0'
+            smw_version: dev-master
+            pf_version: 6.0.8
             php_version: 8.1
             database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.43'
-            smw_version: '6.0.1'
-            pf_version: '6.0'
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mysql:8"
+            database_image: "mariadb:10.11"
             coverage: true
             experimental: false
           - mediawiki_version: '1.44'
             smw_version: dev-master
-            pf_version: '6.0'
+            pf_version: 6.0.8
             php_version: 8.2
+            database_type: mysql
+            database_image: "mariadb:11.4"
+            coverage: false
+            experimental: false
+          - mediawiki_version: '1.45'
+            smw_version: dev-master
+            pf_version: 6.0.8
+            php_version: 8.3
             database_type: mysql
             database_image: "mariadb:11.8"
             coverage: false
             experimental: false
           - mediawiki_version: '1.45'
             smw_version: dev-master
-            pf_version: '6.0'
-            php_version: 8.3
+            pf_version: 6.0.8
+            php_version: 8.4
             database_type: mysql
-            database_image: "mariadb:11.8"
+            database_image: "mariadb:12.3"
             coverage: false
             experimental: false
 
@@ -58,13 +58,12 @@ jobs:
       DB_TYPE: ${{ matrix.database_type }}
       DB_IMAGE: ${{ matrix.database_image }}
 
-      
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
-                   
+
       - name: Update submodules
         run: git submodule update --init --remote
 
@@ -76,8 +75,12 @@ jobs:
         run: make ci-coverage
         if: matrix.coverage == true
 
+      - name: Clean up after CI
+        if: always()
+        run: make destroy
+
       - name: Upload code coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/php/coverage.xml

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<!-- Incomplete/legacy docblocks throughout this pre-existing code base. -->
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPrivate" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingReturn" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.NoParamType" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.ObjectTypeHintParam" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.SpacingAfter" />
+		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate" />
+		<exclude name="MediaWiki.Commenting.PropertyDocumentation.WrongStyle" />
+		<exclude name="MediaWiki.Commenting.MissingCovers.MissingCovers" />
+		<exclude name="MediaWiki.WhiteSpace.SpaceBeforeSingleLineComment.NewLineComment" />
+		<!-- Legacy entry-point filename (SemanticFormsSelect.hooks.php holds class Hooks). -->
+		<exclude name="MediaWiki.Files.ClassMatchesFilename.NotMatch" />
+		<!-- $IP in the test bootstrap is a MediaWiki core global. -->
+		<exclude name="MediaWiki.NamingConventions.ValidGlobalName.allowedPrefix" />
+		<exclude name="Generic.Files.LineLength.TooLong" />
+		<exclude name="Generic.CodeAnalysis.AssignmentInCondition.Found" />
+	</rule>
+	<file>.</file>
+	<exclude-pattern>/(vendor|node_modules|build)/</exclude-pattern>
+	<exclude-pattern type="relative">extensions/*</exclude-pattern>
+	<arg name="extensions" value="php"/>
+	<arg name="encoding" value="UTF-8"/>
+</ruleset>

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,11 @@ EXTENSION := SemanticFormsSelect
 MW_VERSION?=1.43
 PHP_VERSION?=8.1
 DB_TYPE?=mysql
-DB_IMAGE?="mariadb:11.2"
+DB_IMAGE?="mariadb:11.4"
 
 # extensions
-SMW_VERSION?=6.0.1
-PF_VERSION?=6.0
+SMW_VERSION?=dev-master
+PF_VERSION?=6.0.8
 
 # composer
 # Enables "composer update" inside of extension

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,16 @@
 This file contains the RELEASE-NOTES of the Semantic Forms Select (a.k.a. SFS) extension.
 
+### 5.0.0-alpha
+
+Released on TBD.
+
+Compatible with MediaWiki 1.43 up to 1.45, PHP 8.1 up to 8.4, and Semantic MediaWiki 7.0.
+
+* Raised the minimum required Semantic MediaWiki version to 7.0
+* Raised the minimum required Page Forms version to 6.0.6
+* Added support for Semantic MediaWiki 7.0
+* Migrated the query processing to Semantic MediaWiki 7.0's namespaced `SMW\Query\QueryProcessor` API
+
 ### 4.0.0
 
 Released on June 4, 2026.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the latest major version of Semantic Forms
+Select. Please upgrade to the current release before reporting an issue. Fixes
+ship in a new release rather than as backports to older versions.
+
+## Reporting a vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues,
+pull requests, the mailing list, or the project wiki.
+
+Instead, report them privately using GitHub's
+[private vulnerability reporting](https://github.com/SemanticMediaWiki/SemanticFormsSelect/security/advisories/new).
+Please include the affected version, steps to reproduce, and the potential
+impact.
+
+A maintainer will respond to your report, keep you informed of the progress
+towards a fix, and may ask for additional information.
+
+## Disclosure process
+
+To minimise the risk of exploitation, please give us a reasonable opportunity to
+release a fix before any public disclosure. After a report is submitted, we aim
+to:
+
+- Acknowledge the report within 15 days.
+- Confirm the issue and assess its severity and impact.
+- Prepare and release a fix, prioritised by severity, keeping the reporter
+  informed of progress.
+- Publish a security advisory once a fix is available, crediting the reporter
+  unless they prefer to remain anonymous.
+
+Remediation time depends on the severity and complexity of the issue. For
+coordinated disclosure we aim to release a fix within 90 days where feasible.
+
+Because the repository is public and can be watched by potential attackers,
+please avoid describing the vulnerability in public channels, including commit
+messages and issue comments, until a fix has been released.
+
+## Vulnerabilities in MediaWiki or Semantic MediaWiki
+
+Semantic Forms Select is an extension to MediaWiki that builds on Semantic
+MediaWiki. If the issue is actually in one of those rather than in Semantic
+Forms Select itself, please report it there instead:
+
+- For Semantic MediaWiki, use its
+  [private vulnerability reporting](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/new).
+- For MediaWiki core or another extension, contact the
+  [Wikimedia security team](https://www.mediawiki.org/wiki/Reporting_security_bugs).

--- a/SemanticFormsSelect.hooks.php
+++ b/SemanticFormsSelect.hooks.php
@@ -3,9 +3,9 @@
 namespace SFS;
 
 /**
- * @license GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @since 3.0
- * @author: Alexander Gesinn
+ * @author Alexander Gesinn
  */
 class Hooks {
 	/**
@@ -13,10 +13,10 @@ class Hooks {
 	 *
 	 * This is attached to the MediaWiki 'ParserFirstCallInit' hook.
 	 *
-	 * @param $parser Parser
+	 * @param &$parser Parser
 	 * @return bool
 	 */
-	public static function onSemanticFormsSelectSetup ( & $parser ) {
+	public static function onSemanticFormsSelectSetup( &$parser ) {
 		if ( !defined( 'PF_VERSION' ) ) {
 			die( '<b>Error:</b><a href="https://github.com/SemanticMediaWiki/SemanticFormsSelect/">Semantic Forms Select</a> requires the <a href="https://www.mediawiki.org/wiki/Extension:PageForms">Page Forms</a> extension. Please install and activate this extension first.' );
 		}
@@ -32,23 +32,5 @@ class Hooks {
 		if ( isset( $GLOBALS['wgAPIModules'] ) ) {
 			$GLOBALS['wgAPIModules']['sformsselect'] = \SFS\ApiSemanticFormsSelect::class;
 		}
-	}
-
-	/**
-	 * Hook: ResourceLoaderTestModules
-	 * @param array &$modules
-	 */
-	public static function onResourceLoaderTestModules( array &$modules ) {
-		$modules['qunit']['ext.sfs.unit'] = [
-			'scripts' => [
-				'res/sfs.js',
-				'tests/qunit/unit/sfs.test.js'
-			],
-			'dependencies' => [
-				'ext.pageforms.originalValueLookup'
-			],
-			'localBasePath' => __DIR__,
-			'remoteExtPath' => 'SemanticFormsSelect',
-		];
 	}
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,12 @@
 fixes:
   - "/var/www/html/extensions/SemanticFormsSelect/::"
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+        removed_code_behavior: adjust_base
+    patch:
+      default:
+        informational: true

--- a/composer.json
+++ b/composer.json
@@ -41,13 +41,14 @@
 		"composer/installers": ">=1.0.1"
 	},
 	"require-dev": {
+		"mediawiki/mediawiki-codesniffer": "48.0.0",
 		"mediawiki/minus-x": "1.1.3",
 		"php-parallel-lint/php-console-highlighter": "1.0.0",
 		"php-parallel-lint/php-parallel-lint": "1.4.0"
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "4.0.x-dev"
+			"dev-master": "5.x-dev"
 		}
 	},
 	"autoload": {
@@ -58,19 +59,31 @@
 	"config": {
 		"process-timeout": 0,
 		"allow-plugins": {
-			"composer/installers": true
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	},
-	"scripts":{
+	"scripts": {
 		"test": [
-			"@lint",
- 			"minus-x check .",
+			"@analyze",
 			"@phpunit"
 		],
 		"test-coverage": [
+			"@analyze",
 			"@phpunit-coverage"
 		],
+		"analyze": [
+			"@lint",
+			"@phpcs",
+			"@minus-x"
+		],
+		"fix": [
+			"@phpcs-fix"
+		],
 		"lint": "parallel-lint . --exclude vendor --exclude node_modules --exclude extensions",
+		"phpcs": "phpcs -ps",
+		"phpcs-fix": "phpcbf -p",
+		"minus-x": "minus-x check .",
 		"phpunit": "php ${MW_INSTALL_PATH:-../..}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
 		"phpunit-coverage": "php ${MW_INSTALL_PATH:-../..}/tests/phpunit/phpunit.php -c phpunit.xml.dist --testdox --coverage-text --coverage-clover coverage/php/coverage.xml",
 		"post-test-coverage": [

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Semantic Forms Select",
-	"version": "4.0.0",
+	"version": "5.0.0-alpha",
 	"author": [
 		"Jason Zhang",
 		"James Hong Kong",
@@ -16,8 +16,8 @@
 	"requires": {
 		"MediaWiki": ">= 1.43",
 		"extensions": {
-			"SemanticMediaWiki": ">= 6.0",
-			"PageForms": ">= 6.0"
+			"SemanticMediaWiki": ">= 7.0",
+			"PageForms": ">= 6.0.6"
 		}
 	},
 	"AutoloadClasses": {
@@ -66,9 +66,6 @@
 	"Hooks": {
 		"ParserFirstCallInit": [
 			"SFS\\Hooks::onSemanticFormsSelectSetup"
-		],
-		"ResourceLoaderTestModules":[
-			"SFS\\Hooks::onResourceLoaderTestModules"
 		]
 	},
 	"load_composer_autoloader":true,

--- a/src/ApiSemanticFormsSelect.php
+++ b/src/ApiSemanticFormsSelect.php
@@ -3,7 +3,7 @@
 /**
  * API modules to communicate with the back-end
  *
- * @license GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @since 1.2
  *
  * @author Jason Zhang
@@ -17,7 +17,6 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use Parser;
 use ParserOptions;
-use ParserOutput;
 
 class ApiSemanticFormsSelect extends ApiBase {
 

--- a/src/ApiSemanticFormsSelectRequestProcessor.php
+++ b/src/ApiSemanticFormsSelectRequestProcessor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @license GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @since 1.3
  *
  * @author Jason Zhang
@@ -11,10 +11,9 @@
 
 namespace SFS;
 
-use Parser;
-use SMWQueryProcessor;
 use InvalidArgumentException;
-use MWDebug;
+use Parser;
+use SMW\Query\QueryProcessor;
 
 class ApiSemanticFormsSelectRequestProcessor {
 
@@ -24,7 +23,7 @@ class ApiSemanticFormsSelectRequestProcessor {
 	private $parser;
 
 	/**
-	 * @var boolean
+	 * @var bool
 	 */
 	private $debugFlag = false;
 
@@ -34,7 +33,6 @@ class ApiSemanticFormsSelectRequestProcessor {
 	 * @param Parser $parser
 	 * @param null $getSmwResultFromFunctionParams
 	 * @since 1.3
-	 *
 	 */
 	public function __construct( Parser $parser, $getSmwResultFromFunctionParams = null ) {
 		$this->parser = $parser;
@@ -45,7 +43,7 @@ class ApiSemanticFormsSelectRequestProcessor {
 	/**
 	 * @since 1.3
 	 *
-	 * @param boolean $debugFlag
+	 * @param bool $debugFlag
 	 */
 	public function setDebugFlag( $debugFlag ) {
 		$this->debugFlag = $debugFlag;
@@ -59,7 +57,6 @@ class ApiSemanticFormsSelectRequestProcessor {
 	 * @return string
 	 */
 	public function getJsonDecodedResultValuesForRequestParameters( array $parameters ) {
-
 		if ( !isset( $parameters['query'] ) || !isset( $parameters['sep'] ) ) {
 			throw new InvalidArgumentException( 'Missing an query parameter' );
 		}
@@ -82,7 +79,6 @@ class ApiSemanticFormsSelectRequestProcessor {
 	}
 
 	private function doProcessQueryFor( $querystr, $sep = "," ) {
-
 		$querystr = str_replace(
 			[ "&lt;", "&gt;", "sep=;" ],
 			[ "<", ">", "sep={$sep};" ],
@@ -97,7 +93,7 @@ class ApiSemanticFormsSelectRequestProcessor {
 			error_log( implode( "|", $rawparams ) );
 		}
 
-		$result = ($this->getSmwResultFromFunctionParams)($rawparams);
+		$result = ( $this->getSmwResultFromFunctionParams )( $rawparams );
 
 		$values = $this->getFormattedValuesFrom( $sep, $result );
 
@@ -108,23 +104,23 @@ class ApiSemanticFormsSelectRequestProcessor {
 	}
 
 	private function extractRawParameters( $querystr ) {
-		$ensureParameter = function($name, $value) use (&$rawparams) {
-			$rawparams = array_filter($rawparams, function($param) use ($name) {
+		$ensureParameter = static function ( $name, $value ) use ( &$rawparams ) {
+			$rawparams = array_filter( $rawparams, static function ( $param ) use ( $name ) {
 				return substr_compare( $param, "$name=", 0, strlen( "$name=" ) ) !== 0;
-			});
-			if ($value !== null)
+			} );
+			if ( $value !== null ) {
 				$rawparams[] = "$name=$value";
+			}
 		};
 
 		$rawparams = explode( ";", $querystr );
 		// The JavaScript part expects plainlist format for parsing
-		$ensureParameter('format', 'plainlist');
+		$ensureParameter( 'format', 'plainlist' );
 
 		return $rawparams;
 	}
 
 	private function doProcessFunctionFor( $query, $sep = "," ) {
-
 		$query = str_replace(
 			[ "&lt;", "&gt;", "sep=;" ],
 			[ "<", ">", "sep={$sep};" ],
@@ -149,7 +145,6 @@ class ApiSemanticFormsSelectRequestProcessor {
 	}
 
 	private function getFormattedValuesFrom( $sep, $values ) {
-
 		if ( strpos( $values ?? '', $sep ) === false ) {
 			return [ $values ];
 		}
@@ -170,13 +165,13 @@ class ApiSemanticFormsSelectRequestProcessor {
 	 * @return string
 	 */
 	private static function defaultGetSmwResultFromFunctionParams( $rawparams ): string {
-		list( $query, $params ) =
-			SMWQueryProcessor::getQueryAndParamsFromFunctionParams( $rawparams, SMW_OUTPUT_WIKI,
-				SMWQueryProcessor::INLINE_QUERY, false );
+		[ $query, $params ] =
+			QueryProcessor::getQueryAndParamsFromFunctionParams( $rawparams, SMW_OUTPUT_WIKI,
+				QueryProcessor::INLINE_QUERY, false );
 
 		$result =
-			SMWQueryProcessor::getResultFromQuery( $query, $params, SMW_OUTPUT_WIKI,
-				SMWQueryProcessor::INLINE_QUERY );
+			QueryProcessor::getResultFromQuery( $query, $params, SMW_OUTPUT_WIKI,
+				QueryProcessor::INLINE_QUERY );
 
 		return $result;
 	}

--- a/src/Output.php
+++ b/src/Output.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @license GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @since 1.3
  *
  * @author mwjames
@@ -10,7 +10,7 @@
 
 namespace SFS;
 
-//use MWDebug;
+// use MWDebug;
 
 class Output {
 
@@ -26,22 +26,22 @@ class Output {
 	 *
 	 * @param array $data
 	 */
-	public static function addToHeadItem( Array $data = [] ) {
-		return self::$headItems[] = $data;
+	public static function addToHeadItem( array $data = [] ) {
+		self::$headItems[] = $data;
+		return $data;
 	}
 
 	/**
 	 * Commit all SF_Select field parameters to Output
-	 *
 	 */
 	public static function commitToParserOutput() {
 		global $wgOut;	# is there a better way to get $output/$parser without using a global? (testability!)
 
 		// to be used in JS like:
 		// var SFSelect_fobjs = $.parseJSON( mw.config.get( 'sf_select' ) );
-		$wgOut->addJsConfigVars('sf_select', json_encode( self::$headItems ));
+		$wgOut->addJsConfigVars( 'sf_select', json_encode( self::$headItems ) );
 
-		//self::$resourceModules = array();
+		// self::$resourceModules = array();
 		//self::$headItems = array();
 	}
 }

--- a/src/SelectField.php
+++ b/src/SelectField.php
@@ -2,22 +2,20 @@
 
 /**
  * Represents a Select Field.
- * @license GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @since 3.0.0
  * @author: Alexander Gesinn
  */
 
 namespace SFS;
 
-use SMWQueryProcessor as QueryProcessor;
-use Parser;
-use MWDebug;
+use SMW\Query\QueryProcessor;
 
 class SelectField {
 
 	private $mParser = null;
 
-	//private $mSelectField = array();
+	// private $mSelectField = array();
 	private $mValues = null;
 	private $mHasStaticValues = false;
 
@@ -33,7 +31,7 @@ class SelectField {
 	private $mLabel = false;
 	private $mDelimiter = ",";
 
-	public function __construct( & $parser ) {
+	public function __construct( &$parser ) {
 		$this->mParser = $parser;
 	}
 
@@ -61,7 +59,7 @@ class SelectField {
 		$querystr = $other_args["query"];
 		$querystr = str_replace( [ "~", "(", ")" ], [ "=", "[", "]" ], $querystr );
 
-		//$this->mSelectField["query"] = $query;
+		// $this->mSelectField["query"] = $query;
 		$this->mQuery = $querystr;
 		$this->mData['selectquery'] = $querystr;
 
@@ -72,24 +70,24 @@ class SelectField {
 			// there is no need to run the parser, $query has been parsed already
 			//$params[0] = $wgParser->replaceVariables( $params[0] );
 
-			list( $query, $params ) = QueryProcessor::getQueryAndParamsFromFunctionParams( $rawparams, SMW_OUTPUT_WIKI, QueryProcessor::INLINE_QUERY, false );
-			
+			[ $query, $params ] = QueryProcessor::getQueryAndParamsFromFunctionParams( $rawparams, SMW_OUTPUT_WIKI, QueryProcessor::INLINE_QUERY, false );
+
 			$result = QueryProcessor::getResultFromQuery( $query, $params, SMW_OUTPUT_WIKI, QueryProcessor::INLINE_QUERY );
-		
+
 			$this->mValues = $this->getFormattedValuesFrom( $this->mDelimiter, $result );
-		
+
 			$this->setHasStaticValues( true );
 		}
 	}
 
 	public function setFunction( $other_args ) {
-		#global $wgParser;
+		# global $wgParser;
 
 		$function = $other_args["function"];
 		$function = '{{#' . $function . '}}';
 		$function = str_replace( [ "~", "(", ")" ], [ "=", "[", "]" ], $function );
 
-		//$this->mSelectField["function"] = $function;
+		// $this->mSelectField["function"] = $function;
 		$this->mFunction = $function;
 		$this->mData['selectfunction'] = $function;
 
@@ -103,7 +101,7 @@ class SelectField {
 		}
 	}
 
-	public function setSelectIsMultiple( Array $other_args ) {
+	public function setSelectIsMultiple( array $other_args ) {
 		$this->mSelectIsMultiple = array_key_exists( "part_of_multiple", $other_args );
 		$this->mData["selectismultiple"] = $this->mSelectIsMultiple;
 	}
@@ -120,24 +118,23 @@ class SelectField {
 		$this->mData['selectfield'] = $this->mSelectField;
 	}
 
-	public function setValueTemplate( Array $other_args ) {
+	public function setValueTemplate( array $other_args ) {
 		$this->mValueTemplate =
 			array_key_exists( "sametemplate", $other_args ) ? $this->mSelectTemplate : $other_args["template"];
 		$this->mData["valuetemplate"] = $this->mValueTemplate;
 	}
 
-	public function setValueField( Array $other_args ) {
+	public function setValueField( array $other_args ) {
 		$this->mValueField = $other_args["field"];
 		$this->mData["valuefield"] = $this->mValueField;
-
 	}
 
-	public function setSelectRemove( Array $other_args ) {
+	public function setSelectRemove( array $other_args ) {
 		$this->mSelectRemove = array_key_exists( 'rmdiv', $other_args );
 		$this->mData['selectrm'] = $this->mSelectRemove;
 	}
 
-	public function setLabel( Array $other_args ) {
+	public function setLabel( array $other_args ) {
 		$this->mLabel = array_key_exists( 'label', $other_args );
 		$this->mData['label'] = $this->mLabel;
 	}
@@ -146,10 +143,9 @@ class SelectField {
 	 * setDelimiter
 	 * @param array $other_args
 	 */
-	public function setDelimiter( Array $other_args ) {
-		
+	public function setDelimiter( array $other_args ) {
 		$this->mDelimiter = $GLOBALS['wgPageFormsListSeparator'];
-		
+
 		if ( array_key_exists( 'sep', $other_args ) ) {
 			$this->mDelimiter = $other_args['sep'];
 		} else {
@@ -188,11 +184,10 @@ class SelectField {
 	private function setHasStaticValues( $StaticValues ) {
 		$this->mHasStaticValues = $StaticValues;
 	}
-	
-	/** Copied from ApiSemanticFormsSelectRequestProcessor */
-	
-	private function getFormattedValuesFrom( $sep, $values ) {
 
+	/** Copied from ApiSemanticFormsSelectRequestProcessor */
+
+	private function getFormattedValuesFrom( $sep, $values ) {
 		if ( strpos( $values, $sep ) === false ) {
 			return [ $values ];
 		}

--- a/src/SemanticFormsSelectInput.php
+++ b/src/SemanticFormsSelectInput.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @license GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @since 1.3
  *
  * @author Jason Zhang
@@ -14,11 +14,9 @@ namespace SFS;
 use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
-use SMWQueryProcessor as QueryProcessor;
 use Parser;
 use ParserOptions;
 use PFFormInput;
-use MWDebug;
 
 class SemanticFormsSelectInput extends PFFormInput {
 
@@ -90,8 +88,8 @@ class SemanticFormsSelectInput extends PFFormInput {
 	 * @param    string[] $other_args Array of other field parameters
 	 * @return string
 	 */
-	public function getHTML( $is_mandatory, $is_disabled, Array $other_args, $cur_value = "", $input_name = "" ) {
-		global $wgPageFormsFieldNum, $wgUser;
+	public function getHTML( $is_mandatory, $is_disabled, array $other_args, $cur_value = "", $input_name = "" ) {
+		global $wgPageFormsFieldNum;
 
 		// Build the SelectField (and its dedicated, initialized parser) lazily
 		// here rather than overriding the constructor. This keeps the class
@@ -125,7 +123,7 @@ class SemanticFormsSelectInput extends PFFormInput {
 			$selectField->setValueField( $other_args );
 			$selectField->setSelectRemove( $other_args );
 
-			$item = Output::addToHeadItem( $selectField->getData() );
+			Output::addToHeadItem( $selectField->getData() );
 		}
 
 		Output::commitToParserOutput();
@@ -167,13 +165,13 @@ class SemanticFormsSelectInput extends PFFormInput {
 		// TODO Use Html::
 
 		$spanextra = $is_mandatory ? 'mandatoryFieldSpan' : '';
-		$is_single_select = (!$is_list) ? 'select-sfs-single' : '' ;
+		$is_single_select = ( !$is_list ) ? 'select-sfs-single' : '';
 		$ret = "<span class=\"inputSpan select-sfs $is_single_select $spanextra\"><select name='$inname' id='input_$wgPageFormsFieldNum' $extraatt>";
 
 		$curvalues = null;
 		if ( $cur_value ) {
 			if ( $cur_value === 'current user' ) {
-				$cur_value = $wgUser->getName();
+				$cur_value = RequestContext::getMain()->getUser()->getName();
 			}
 			if ( is_array( $cur_value ) ) {
 				$curvalues = $cur_value;
@@ -185,7 +183,6 @@ class SemanticFormsSelectInput extends PFFormInput {
 		} else {
 			$curvalues = [];
 		}
-
 
 		$labelArray = [];
 		if ( array_key_exists( "label", $other_args ) && $curvalues ) {
@@ -215,7 +212,7 @@ class SemanticFormsSelectInput extends PFFormInput {
 							$selected = " selected='selected'";
 						}
 
-						$ret.="<option".$selected." value='".$labelArray[ $val ][0]."'>".$labelArray[ $val ][1]."</option>";
+						$ret .= "<option" . $selected . " value='" . $labelArray[ $val ][0] . "'>" . $labelArray[ $val ][1] . "</option>";
 
 					} else {
 
@@ -232,7 +229,7 @@ class SemanticFormsSelectInput extends PFFormInput {
 							$selected = " selected='selected'";
 						}
 
-						$ret .= "<option".$selected.">$val</option>";
+						$ret .= "<option" . $selected . ">$val</option>";
 					}
 				}
 			}
@@ -247,13 +244,13 @@ class SemanticFormsSelectInput extends PFFormInput {
 						$selected = " selected='selected'";
 					}
 
-					$ret.="<option".$selected." value='".$labelArray[ $cur ][0]."'>".$labelArray[ $cur ][1]."</option>";
+					$ret .= "<option" . $selected . " value='" . $labelArray[ $cur ][0] . "'>" . $labelArray[ $cur ][1] . "</option>";
 
 				} else {
 					if ( in_array( $cur, $curvalues ) ) {
 						$selected = " selected='selected'";
 					}
-					$ret.="<option".$selected.">$cur</option>";
+					$ret .= "<option" . $selected . ">$cur</option>";
 				}
 			}
 
@@ -270,10 +267,8 @@ class SemanticFormsSelectInput extends PFFormInput {
 		return $ret;
 	}
 
-
 	private function getLabels( $labels ) {
-
-		$labelArray = [ ];
+		$labelArray = [];
 
 		if ( is_array( $labels ) ) {
 			foreach ( $labels as $label ) {
@@ -289,7 +284,7 @@ class SemanticFormsSelectInput extends PFFormInput {
 					$doneBr = 0;
 					$num = 0;
 
-					$labelArr = str_split ( $label );
+					$labelArr = str_split( $label );
 
 					$end = count( $labelArr ) - 1;
 					$iter = $end;
@@ -323,17 +318,16 @@ class SemanticFormsSelectInput extends PFFormInput {
 
 					}
 
-					$labelValue = implode( "", array_slice( $labelArr, $startBr+1, $endBr-$startBr-1 ) );
-					$labelKey = implode( "", array_slice( $labelArr, 0, $startBr-1 ) );
+					$labelValue = implode( "", array_slice( $labelArr, $startBr + 1, $endBr - $startBr - 1 ) );
+					$labelKey = implode( "", array_slice( $labelArr, 0, $startBr - 1 ) );
 
 				}
 
-				$labelArray[ $label ] = [ $labelKey, $labelValue ] ;
+				$labelArray[ $label ] = [ $labelKey, $labelValue ];
 			}
 
 		}
 
 		return $labelArray;
-
 	}
 }

--- a/template.env
+++ b/template.env
@@ -1,2 +1,2 @@
 DB_TYPE=mysql
-DB_IMAGE="mariadb:latest"
+DB_IMAGE="mariadb:11.4"

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,7 +10,7 @@ ini_set( 'display_errors', 1 );
 
 global $IP;
 
-//if ( !is_readable( $autoloaderClassPath = __DIR__ . '/../../SemanticMediaWiki/tests/autoloader.php' ) ) {
+// if ( !is_readable( $autoloaderClassPath = __DIR__ . '/../../SemanticMediaWiki/tests/autoloader.php' ) ) {
 if ( !is_readable( $autoloaderClassPath = $IP . '/extensions/SemanticMediaWiki/tests/autoloader.php' ) ) {
 	die( "\nThe Semantic MediaWiki test autoloader is not available\n" );
 }
@@ -20,7 +20,7 @@ if ( ExtensionRegistry::getInstance()->isLoaded( 'SemanticFormsSelect' ) ) {
 	die( "\nSemantic Forms Select is not available, please check your Composer or LocalSettings.\n" );
 }
 
-//print sprintf( "\n%-20s%s\n", "Semantic Forms Select: ", ExtensionRegistry::getInstance()->isLoaded( 'SemanticFormsSelect' ) );
+// print sprintf( "\n%-20s%s\n", "Semantic Forms Select: ", ExtensionRegistry::getInstance()->isLoaded( 'SemanticFormsSelect' ) );
 //print sprintf( "%-20s%s\n", "Page Forms: ", SemanticFormsSelect::getVersion( 'PageForms' ) );
 
 $autoloader = require $autoloaderClassPath;

--- a/tests/phpunit/Unit/ApiSemanticFormsSelectRequestProcessorTest.php
+++ b/tests/phpunit/Unit/ApiSemanticFormsSelectRequestProcessorTest.php
@@ -2,17 +2,13 @@
 
 namespace SFS\Tests;
 
-use MediaWiki\Api\ApiMain;
-use MediaWiki\Context\RequestContext;
-use MediaWiki\Request\WebRequest;
-use MediaWiki\Request\FauxRequest;
 use SFS\ApiSemanticFormsSelectRequestProcessor;
 
 /**
  * @covers  \SFS\ApiSemanticFormsSelectRequestProcessor
  * @group   semantic-forms-select
  *
- * @license GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @since   3.0.0
  *
  * @author  FelixAba
@@ -39,7 +35,6 @@ class ApiSemanticFormsSelectRequestProcessorTest
 	}
 
 	public function testMissingParametersThrowsException() {
-
 		$parameters = [];
 
 		$this->expectException( 'InvalidArgumentException' );
@@ -49,7 +44,6 @@ class ApiSemanticFormsSelectRequestProcessorTest
 	}
 
 	public function testJsonResultValuesFromRequestParameters() {
-
 		$parameters = [ 'query' => 'foo', 'sep' => ',' ];
 
 		$this->assertIsObject(
@@ -59,11 +53,9 @@ class ApiSemanticFormsSelectRequestProcessorTest
 		);
 	}
 
-	public function testJsonResultValuesFromRequestParameters_doProcessQueryFor(
-	) {
-
+	public function testJsonResultValuesFromRequestParameters_doProcessQueryFor() {
 		$parameters = [ 'approach' => 'smw', 'query' => 'foo, baa, gaah',
-		                     'sep'      => ',' ];
+							 'sep'      => ',' ];
 
 		$this->assertIsObject(
 			$this->ApiSFSRP->getJsonDecodedResultValuesForRequestParameters(
@@ -86,7 +78,7 @@ class ApiSemanticFormsSelectRequestProcessorTest
 	public function testSetDebugFlag_doProcessQueryFor() {
 		$this->ApiSFSRP->setDebugFlag( true );
 		$parameters = [ 'approach' => 'smw', 'query' => 'my Query,query2',
-		                     'sep'      => ',' ];
+							 'sep'      => ',' ];
 
 		$this->assertIsObject(
 			$this->ApiSFSRP->getJsonDecodedResultValuesForRequestParameters(
@@ -107,7 +99,7 @@ class ApiSemanticFormsSelectRequestProcessorTest
 
 	public function testExistingSmwFormatIsOverwrittenByPlainlist() {
 		$calledWithRawparams = [];
-		$getResultFromFunctionParams = function ( $rawparams ) use ( &$calledWithRawparams ) {
+		$getResultFromFunctionParams = static function ( $rawparams ) use ( &$calledWithRawparams ) {
 			array_push( $calledWithRawparams, ...$rawparams );
 		};
 		$processor = new ApiSemanticFormsSelectRequestProcessor( $this->getParser(), $getResultFromFunctionParams );
@@ -130,7 +122,7 @@ class ApiSemanticFormsSelectRequestProcessorTest
 	 *
 	 * @return mixed Method return.
 	 */
-	public function invokeMethod(&$object, $methodName,
+	public function invokeMethod( &$object, $methodName,
 		array $parameters = []
 	) {
 		$reflection = new \ReflectionClass( get_class( $object ) );

--- a/tests/phpunit/Unit/ApiSemanticFormsSelectTest.php
+++ b/tests/phpunit/Unit/ApiSemanticFormsSelectTest.php
@@ -4,15 +4,15 @@ namespace SFS\Tests;
 
 use MediaWiki\Api\ApiMain;
 use MediaWiki\Context\RequestContext;
-use MediaWiki\Request\WebRequest;
 use MediaWiki\Request\FauxRequest;
+use MediaWiki\Request\WebRequest;
 use SFS\ApiSemanticFormsSelect;
 
 /**
  * @covers  \SFS\ApiSemanticFormsSelect
  * @group   semantic-forms-select
  *
- * @license GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @since   1.3
  *
  * @author  mwjames
@@ -25,7 +25,7 @@ class ApiSemanticFormsSelectTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$parameters = [ 'action' => 'sformsselect', 'approach' => 'smw',
-		                     'query'  => 'abc', 'sep' => ',' ];
+							 'query'  => 'abc', 'sep' => ',' ];
 
 		$this->ApiMain = new ApiMain(
 			$this->newRequestContext( $parameters ), true
@@ -41,9 +41,7 @@ class ApiSemanticFormsSelectTest extends \PHPUnit\Framework\TestCase {
 		parent::tearDown();
 	}
 
-
 	public function testCanConstruct() {
-
 		$apiMain = new ApiMain( $this->newRequestContext( [] ), true );
 
 		$instance = new ApiSemanticFormsSelect(
@@ -56,7 +54,6 @@ class ApiSemanticFormsSelectTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testExecute() {
-
 		$this->assertTrue(
 			$this->ApiSFS->execute()
 		);
@@ -69,7 +66,7 @@ class ApiSemanticFormsSelectTest extends \PHPUnit\Framework\TestCase {
 
 	public function testGetParamDescription() {
 		$tdata = [ 'approach' => 'The actual approach: function or smw',
-		                'query'    => 'The query of the former' ];
+						'query'    => 'The query of the former' ];
 		$this->assertEquals( $this->ApiSFS->getParamDescription(), $tdata );
 	}
 
@@ -78,9 +75,7 @@ class ApiSemanticFormsSelectTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( $this->ApiSFS->getVersion(), $tdata );
 	}
 
-
 	private function newRequestContext( $request = [] ) {
-
 		$context = new RequestContext();
 
 		if ( $request instanceof WebRequest ) {

--- a/tests/phpunit/Unit/OutputTest.php
+++ b/tests/phpunit/Unit/OutputTest.php
@@ -8,7 +8,7 @@ use SFS\Output;
  * @covers  \SFS\Output
  * @group   semantic-forms-select
  *
- * @license GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @since   1.3
  *
  * @author  mwjames

--- a/tests/phpunit/Unit/SelectFieldTest.php
+++ b/tests/phpunit/Unit/SelectFieldTest.php
@@ -21,7 +21,7 @@ use SFS\SelectField;
  */
 class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	private $selectField;
-	
+
 	private $other_args_query_parametrized = [ 'query' => '((Category:Building Complex))((Part Of Site::@@@@));?Display Title;format~list;sort~Display Title;sep~,;link~none;headers~hide;limit~500' ];
 	private $expected_result_parametrized_setQuery = "[[Category:Building Complex]][[Part Of Site::@@@@]];?Display Title;format=list;sort=Display Title;sep=,;link=none;headers=hide;limit=500";
 	private $other_args_query_unparametrized = [ 'query' => '((Category:Building Complex));?Display Title;format~list;sort~Display Title;sep~,;link~none;headers~hide;limit~500' ];
@@ -30,22 +30,19 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	private $other_args_function_unparametrized = [ 'function' => 'ask:((Category:Building Complex));?Display Title;format~list;sort~Display Title;sep~@@;link~none;headers~hide;limit~500' ];
 
 	public function testCanConstruct() {
-
 		$this->assertInstanceOf( '\SFS\SelectField', $this->selectField );
 	}
 
 	public function testProcessParameters_Query() {
-
 		$this->selectField->processParameters(
 			$this->other_args_query_parametrized, ""
 		);
-		$this->assertTrue(
-			array_key_exists( "query", $this->other_args_query_parametrized )
+		$this->assertArrayHasKey(
+			"query", $this->other_args_query_parametrized
 		);
 	}
 
 	public function testProcessParameters_Function() {
-
 		$this->selectField->processParameters(
 			$this->other_args_function_parametrized, ""
 		);
@@ -55,7 +52,6 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testParametrized_setQuery() {
-
 		$this->selectField->setQuery( $this->other_args_query_parametrized );
 
 		$this->assertEquals(
@@ -80,7 +76,6 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testUnparametrized_setQuery() {
-
 		$this->selectField->setQuery( $this->other_args_query_unparametrized );
 
 		$this->assertTrue( $this->selectField->getValues() !== null );
@@ -88,7 +83,6 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testParametrized_setFunction() {
-
 		$this->selectField->setFunction(
 			$this->other_args_function_parametrized
 		);
@@ -101,7 +95,6 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testUnparametrized_setFunction() {
-
 		$this->selectField->setFunction(
 			$this->other_args_function_unparametrized
 		);
@@ -116,7 +109,6 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testSetSelectIsMultiple_keyExistFalse() {
-
 		$other_args = [ "Not_part_of_multiple" => "blas blas blas" ];
 		$this->selectField->setSelectIsMultiple( $other_args );
 		$this->assertFalse( $this->selectField->getData()["selectismultiple"] );
@@ -176,7 +168,6 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testSetValueTemplate_containsOtherArgsTemplate() {
-
 		$other_args = [ "template" => "test values" ];
 
 		$this->selectField->setValueTemplate( $other_args );
@@ -204,7 +195,6 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testSetSelectRemove_keyExistFalse() {
-
 		$other_args = [ "no_rmdiv" => "test data" ];
 		$this->selectField->setSelectRemove( $other_args );
 		$this->assertFalse( $this->selectField->getData()["selectrm"] );
@@ -217,7 +207,6 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testSetLabel_keyExistFalse() {
-
 		$other_args = [ "no_label" => "test data" ];
 		$this->selectField->setLabel( $other_args );
 		$this->assertArrayHasKey( "label", $this->selectField->getData() );
@@ -236,7 +225,6 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testSetWgPageFormsListSeparator_keyExistTrue() {
-
 		$g_args = [ "delimiter" => ";" ];
 		$this->selectField->setDelimiter( $g_args );
 		$this->assertEquals(
@@ -257,9 +245,9 @@ class SelectFieldTest extends \PHPUnit\Framework\TestCase {
 
 		$parserOption = new ParserOptions( $user );
 		$parser = MediaWikiServices::getInstance()->getParser();
-		$parser->setOutputType(Parser::OT_HTML);
+		$parser->setOutputType( Parser::OT_HTML );
 		$parser->setTitle( Title::newFromText( 'NO TITLE' ) );
-		$parser->setOptions($parserOption);
+		$parser->setOptions( $parserOption );
 		$parser->resetOutput();
 		$parser->clearState();
 		$this->selectField = new SelectField( $parser );

--- a/tests/phpunit/Unit/SemanticFormsSelectInputTest.php
+++ b/tests/phpunit/Unit/SemanticFormsSelectInputTest.php
@@ -2,13 +2,14 @@
 
 namespace SFS\Tests;
 
+use MediaWiki\Context\RequestContext;
 use SFS\SemanticFormsSelectInput;
 
 /**
  * @covers  \SFS\SemanticFormsSelectInput
  * @group   semantic-forms-select
  *
- * @license GNU GPL v2+
+ * @license GPL-2.0-or-later
  * @since   3.0.0
  *
  * @author  FelixAba
@@ -17,16 +18,17 @@ class SemanticFormsSelectInputTest extends \PHPUnit\Framework\TestCase {
 
 	private $SFSInput;
 
-
 	protected function setUp(): void {
 		parent::setUp();
 
 		$otherArgs = [ 'template' => 'Foo', 'field' => '',
-		                    'function' => 'Bar', 'is_list' => true ];
+							'function' => 'Bar', 'is_list' => true ];
 
-		// $inputNumber, $curValue, $inputName, $disabled, $otherArgs
+		// Page Forms 6.0.6+ takes the OutputPage as the leading constructor argument.
+		// $out, $inputNumber, $curValue, $inputName, $disabled, $otherArgs
+		$out = RequestContext::getMain()->getOutput();
 		$this->SFSInput = new SemanticFormsSelectInput(
-			1, '', 'TestTemplate[Field]', false, $otherArgs
+			$out, 1, '', 'TestTemplate[Field]', false, $otherArgs
 		);
 	}
 
@@ -56,7 +58,6 @@ class SemanticFormsSelectInputTest extends \PHPUnit\Framework\TestCase {
 	public function testGetParameters() {
 		$this->assertIsArray( $this->SFSInput->getParameters() );
 	}
-
 
 	public function testGetResourceModuleNames() {
 		$result = $this->SFSInput->getResourceModuleNames();


### PR DESCRIPTION
## Summary

Adds support for **Semantic MediaWiki 7.0** and modernises the extension's tooling and CI. The extension's own major is bumped to `5.0.0-alpha` (strict semver — independent of the SMW major it targets).

## Changes

**Requirements & version**
- `requires`: Semantic MediaWiki `>= 7.0` (was `>= 6.0`), Page Forms `>= 6.0.6`, MediaWiki `>= 1.43` (unchanged)
- `extension.json` version `4.0.0` → `5.0.0-alpha`; composer branch alias `dev-master` → `5.x-dev`

**Semantic MediaWiki 7.0 API**
- Migrated query processing from the deprecated `SMWQueryProcessor` alias to the namespaced `SMW\Query\QueryProcessor` (`SelectField`, `ApiSemanticFormsSelectRequestProcessor`). The alias still works in 7.0 but is slated for removal; the namespaced class, its `getQueryAndParamsFromFunctionParams`/`getResultFromQuery` methods, `INLINE_QUERY`, and `SMW_OUTPUT_WIKI` are all present in SMW 7.0.

**Toolchain**
- Added `mediawiki/mediawiki-codesniffer`, a `.phpcs.xml` MediaWiki ruleset, and `analyze`/`phpcs`/`phpcs-fix`/`minus-x`/`fix` composer scripts so `make ci`/`make analyze` run a full lint + sniff + minus-x pass.

**CI**
- Reworked the matrix to a per-row MariaDB LTS spread (`10.11`/`11.4`/`11.8`/`12.3`) across MediaWiki 1.43–1.45 with Semantic MediaWiki `dev-master` and Page Forms `6.0.8`; dropped the MySQL leg and the EOL `mariadb:11.2` image.
- Bumped actions to `actions/checkout@v6` and `codecov/codecov-action@v6`; made code coverage `informational` so it never gates CI.

**Cleanup**
- Removed the dead `ResourceLoaderTestModules` hook handler + registration (the hook was removed from MediaWiki in 1.41 and pointed at a non-existent test file).
- Replaced the deprecated `$wgUser` global with the request context; dropped unused imports; updated license headers to the `GPL-2.0-or-later` SPDX identifier.
- Updated the `SemanticFormsSelectInput` unit test to Page Forms' 6.0.6+ constructor (leading `OutputPage` argument).

## Verification

Run in a container with MediaWiki 1.43 + Semantic MediaWiki `dev-master` (7.0) + Page Forms 6.0.8:
- `composer analyze` → clean (parallel-lint + phpcs + minus-x, exit 0)
- `composer phpunit` → OK, 43 tests, 50 assertions
- Live `action=sformsselect&approach=smw` query returned seeded results via the migrated `QueryProcessor`
- Live `Special:FormEdit` rendered the `SF_Select` input (`<select class="select-sfs">`) populated from an SMW query

## Reviewer note

Much of the line-level diff is `phpcbf` reformatting — whitespace, list syntax, and CRLF→LF normalisation (MediaWiki requires LF; the sniffer enforces it). The substantive changes are the `QueryProcessor` migration, the dead-hook/`$wgUser`/import cleanup, and the version/requirements/CI updates; `git diff -w` isolates them.

A `SECURITY.md` (private vulnerability reporting policy) is included as a separate commit.